### PR TITLE
Patch for issue #51.

### DIFF
--- a/rv-predict-agent/src/rvpredict/instrumentation/SnoopInstructionClassAdapter.java
+++ b/rv-predict-agent/src/rvpredict/instrumentation/SnoopInstructionClassAdapter.java
@@ -11,6 +11,7 @@ import rvpredict.config.Config;
 public class SnoopInstructionClassAdapter extends ClassVisitor {
 	
 	private String classname;
+    private String source;
 	
     public SnoopInstructionClassAdapter(ClassVisitor cv) {
         super(Opcodes.ASM5,cv);
@@ -25,8 +26,16 @@ public class SnoopInstructionClassAdapter extends ClassVisitor {
         classname = name;
         if(Config.instance.verbose)
         System.out.println("classname: "+classname);
-    } 
-    
+    }
+
+    @Override
+    public void visitSource(String source, String debug) {
+        this.source = source;
+        if (cv != null) {
+            cv.visitSource(source, debug);
+        }
+    }
+
     public FieldVisitor visitField(int access, String name, String desc,
             String signature, Object value) {
 		String sig_var = (classname+"."+name).replace("/", ".");
@@ -67,7 +76,7 @@ public class SnoopInstructionClassAdapter extends ClassVisitor {
         			length++;
         	}
 //            System.out.println("******************* "+((access & Opcodes.ACC_STATIC)>0));
-            mv = new SnoopInstructionMethodAdapter(mv,classname,name,name+desc,name.equals("<init>")||name.equals("<clinit>"), isSynchronized,isStatic,length);
+            mv = new SnoopInstructionMethodAdapter(mv,source, classname,name,name+desc,name.equals("<init>")||name.equals("<clinit>"), isSynchronized,isStatic,length);
            
         }
 

--- a/rv-predict-agent/src/rvpredict/instrumentation/SnoopInstructionMethodAdapter.java
+++ b/rv-predict-agent/src/rvpredict/instrumentation/SnoopInstructionMethodAdapter.java
@@ -27,13 +27,15 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
 
     boolean isInit,isSynchronized,isStatic;
     String classname;
+    String source;
     String methodname;
     String methodsignature;
     private int maxindex_cur;//current max index of local variables 
     private int line_cur;
     
-    public SnoopInstructionMethodAdapter(MethodVisitor mv, String cname,String mname, String msignature,boolean isInit, boolean isSynchronized, boolean isStatic, int argSize) {
+    public SnoopInstructionMethodAdapter(MethodVisitor mv, String source, String cname, String mname, String msignature, boolean isInit, boolean isSynchronized, boolean isStatic, int argSize) {
         super(Opcodes.ASM5,mv);
+        this.source = source == null ? "Unknown" : source;
         this.classname = cname;
         this.methodname = mname;
         this.methodsignature = msignature;
@@ -214,7 +216,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
         		mv.visitMethodInsn(opcode, owner, name, desc); 
         	else
         	{
-            	String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+            	String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
             	int ID  = GlobalStateForInstrumentation.instance.getLocationId(sig_loc);
         		
 	        	if(name.equals("start") &&desc.equals("()V")) {
@@ -304,7 +306,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	//signature + line number
     	String sig_var = (owner+"."+name).replace("/", ".");
     	int SID = GlobalStateForInstrumentation.instance.getVariableId(sig_var);
-    	String sig_loc = (classname+"|"+methodsignature+"|"+sig_var+"|"+line_cur).replace("/", ".");
+    	String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+sig_var+"|"+line_cur).replace("/", ".");
     	int ID  = GlobalStateForInstrumentation.instance.getLocationId(sig_loc);
         switch (opcode) {
             case GETSTATIC:
@@ -669,7 +671,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	case AALOAD:
     		if(!isInit)
     		{
-    			String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    			String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
     	    	
     			if(Config.detectSharingOnly)
@@ -732,7 +734,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	case IALOAD:
     		if(!isInit)
     		{
-    			String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    			String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
     	    	
     			if(Config.detectSharingOnly)
@@ -791,7 +793,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	case FALOAD:
     		if(!isInit)
     		{
-    			String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    			String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
     	    	
     			if(Config.detectSharingOnly)
@@ -852,7 +854,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	case DALOAD:
     		if(!isInit)
     		{
-    			String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    			String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
     	    	
     			if(Config.detectSharingOnly)
@@ -912,7 +914,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	case LALOAD:
     		if(!isInit)
     		{
-    			String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    			String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
     	    	
     			if(Config.detectSharingOnly)
@@ -971,7 +973,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     		break;
     	case AASTORE:
     	{
-			String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+			String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
 	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
 	    	
 			if(Config.detectSharingOnly)
@@ -1052,7 +1054,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	case SASTORE:
     	case IASTORE:	
     	{
-    		String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    		String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
 	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
 	    	
 			if(Config.detectSharingOnly)
@@ -1130,7 +1132,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	}
     	case FASTORE:
     	{
-    		String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    		String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
 	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
 	    	
 			if(Config.detectSharingOnly)
@@ -1208,7 +1210,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	}
     	case DASTORE:
     	{
-    		String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    		String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
 	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
 	    	
 			if(Config.detectSharingOnly)
@@ -1284,7 +1286,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	}
     	case LASTORE:
     	{
-    		String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+    		String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
 	    	int ID  = GlobalStateForInstrumentation.instance.getArrayLocationId(sig_loc);
 	    	
 			if(Config.detectSharingOnly)
@@ -1361,7 +1363,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	case MONITORENTER:{
     		if(!Config.detectSharingOnly)
     		{
-        		String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+        		String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getLocationId(sig_loc);
     	    	
 	    		mv.visitInsn(DUP);
@@ -1382,7 +1384,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	{
     		if(!Config.detectSharingOnly)
     		{
-        		String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+        		String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getLocationId(sig_loc);
     	    	
 	    		mv.visitInsn(DUP);
@@ -1407,7 +1409,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     		if(isSynchronized
     				&&!Config.detectSharingOnly)
     		{
-        		String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+        		String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
     	    	int ID  = GlobalStateForInstrumentation.instance.getLocationId(sig_loc);
     	    	
     	    	addBipushInsn(mv,ID);
@@ -1439,7 +1441,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
     	if(isSynchronized
     			&&!Config.detectSharingOnly)
 		{
-        	String sig_loc = (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
+        	String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+line_cur).replace("/", ".");
         	int ID  = GlobalStateForInstrumentation.instance.getLocationId(sig_loc);
         	
 	    	addBipushInsn(mv,ID);

--- a/rv-predict-engine/src/engines/CPRaceDetect.java
+++ b/rv-predict-engine/src/engines/CPRaceDetect.java
@@ -142,7 +142,7 @@ public class CPRaceDetect {
 							
 							if(engine.isRace(rnode, wnode))
 							{
-								report("Race: "+race,MSGTYPE.REAL);
+								report(race.toString(),MSGTYPE.REAL);
 								//report(rnode.getGID()+"--"+wnode.getGID(),false);
 								if(config.allrace)
 								{
@@ -176,7 +176,7 @@ public class CPRaceDetect {
 							{
 								if(engine.isRace(wnode1, wnode2))
 								{
-									report("Race: "+race,MSGTYPE.REAL);
+									report(race.toString(),MSGTYPE.REAL);
 									if(config.allrace)
 									{
 										ExactRace race2 = new ExactRace(race,(int)wnode1.getGID(),(int)wnode2.getGID());

--- a/rv-predict-engine/src/rvpredict/engine/main/HBRaceDetect.java
+++ b/rv-predict-engine/src/rvpredict/engine/main/HBRaceDetect.java
@@ -141,7 +141,7 @@ public class HBRaceDetect {
 							
 							if(engine.isRace(rnode, wnode))
 							{
-								report("Race: "+race,MSGTYPE.REAL);
+								report(race.toString(),MSGTYPE.REAL);
 								//report(rnode.getGID()+"--"+wnode.getGID(),false);
 								if(config.allrace)
 								{
@@ -174,7 +174,7 @@ public class HBRaceDetect {
 							{
 								if(engine.isRace(wnode1, wnode2))
 								{
-									report("Race: "+race,MSGTYPE.REAL);
+									report(race.toString(),MSGTYPE.REAL);
 									if(config.allrace)
 									{
 										ExactRace race2 = new ExactRace(race,(int)wnode1.getGID(),(int)wnode2.getGID());

--- a/rv-predict-engine/src/rvpredict/engine/main/NewRVPredict.java
+++ b/rv-predict-engine/src/rvpredict/engine/main/NewRVPredict.java
@@ -574,7 +574,7 @@ public class NewRVPredict {
 							{
 								//real race found
 								
-								report("Race: "+race,MSGTYPE.REAL);//report it
+								report(race.toString(),MSGTYPE.REAL);//report it
 								if(config.allrace)violations.add(race2);//save it to violations
 								else violations.add(race);
 								
@@ -596,7 +596,7 @@ public class NewRVPredict {
 											Race r=new Race(trace.getStmtSigIdMap().get(node1.getID()),
 													trace.getStmtSigIdMap().get(node2.getID()),node1.getID(),node2.getID() );
 										if(violations.add(r))
-											report("Race: "+r,MSGTYPE.REAL);
+											report(r.toString(),MSGTYPE.REAL);
 										
 										}
 									}
@@ -659,7 +659,7 @@ public class NewRVPredict {
 								//if we arrive here, it means we find a case where 
 								//lockset+happens-before could produce false positive
 								if(potentialviolations.add(race2))
-									report("Potential Race: "+race2,MSGTYPE.POTENTIAL);
+									report("Potential "+race2,MSGTYPE.POTENTIAL);
 
 								if(equiMap.containsKey(rnode)||equiMap.containsKey(wnode))
 								{
@@ -680,7 +680,7 @@ public class NewRVPredict {
 											ExactRace r = new ExactRace(trace.getStmtSigIdMap().get(node1.getID()),
 													trace.getStmtSigIdMap().get(node2.getID()),(int)node1.getGID(),(int)node2.getGID() );
 											if(potentialviolations.add(r))
-												report("Potential Race: "+r,MSGTYPE.POTENTIAL);
+												report("Potential "+r,MSGTYPE.POTENTIAL);
 											
 										}
 									}
@@ -748,7 +748,7 @@ public class NewRVPredict {
 								//TODO: NEED to ensure that the other non-dependent nodes by other threads are not included
 								if(engine.isRace(wnode1, wnode2,sb))
 								{
-									report("Race: "+race,MSGTYPE.REAL);
+									report(race.toString(),MSGTYPE.REAL);
 
 									if(config.allrace)violations.add(race2);//save it to violations
 									else violations.add(race);									
@@ -771,7 +771,7 @@ public class NewRVPredict {
 												Race r=new Race(trace.getStmtSigIdMap().get(node1.getID()),
 														trace.getStmtSigIdMap().get(node2.getID()),node1.getID(),node2.getID() );
 											if(violations.add(r))
-												report("Race: "+r,MSGTYPE.REAL);
+												report(r.toString(),MSGTYPE.REAL);
 												
 
 											}
@@ -828,7 +828,7 @@ public class NewRVPredict {
 								{
 									//if we arrive here, it means we find a case where lockset+happens-before could produce false positive
 									if(potentialviolations.add(race2))
-										report("Potential Race: "+race2,MSGTYPE.POTENTIAL);
+										report("Potential "+race2,MSGTYPE.POTENTIAL);
 									
 									if(equiMap.containsKey(wnode1)||equiMap.containsKey(wnode2))
 									{
@@ -848,7 +848,7 @@ public class NewRVPredict {
 												ExactRace r = new ExactRace(trace.getStmtSigIdMap().get(node1.getID()),
 														trace.getStmtSigIdMap().get(node2.getID()),(int)node1.getGID(),(int)node2.getGID() );
 												if(potentialviolations.add(r))
-													report("Potential Race: "+r,MSGTYPE.POTENTIAL);
+													report("Potential "+r,MSGTYPE.POTENTIAL);
 												
 
 											}

--- a/rv-predict-engine/src/violation/Race.java
+++ b/rv-predict-engine/src/violation/Race.java
@@ -98,8 +98,48 @@ public class Race implements IViolation{
 	@Override
 	public String toString()
 	{
-		return node1+" - "+node2;
+        // Assuming
+        // String sig_loc = source + "|" + (classname+"|"+methodsignature+"|"+sig_var+"|"+line_cur).replace("/", ".");
+        Location loc1 = new Location(node1);
+        String result = "Race on field " + loc1.varSignature + " between";
+        if (node1 == node2) {
+            result += " two instances of:\n" +
+                    "\t" + loc1 + "\n";
+        } else {
+            Location loc2 = new Location(node2);
+            result += ":\n" +
+                    "\t" + loc1 + "\n" +
+                    "\t" + loc2 + "\n";
+        }
+        return result;
 	}
+
+    class Location {
+        String source;
+        String className;
+        String methodName;
+        String methodSignature;
+        String varSignature;
+        String line;
+
+        Location(String descriptor) {
+            String[] fields = descriptor.split("\\|");
+            source = fields[0];
+            className = fields[1];
+            int par = fields[2].indexOf('(');
+            methodName = fields[2].substring(0, par);
+            methodSignature = fields[2].substring(par);
+            varSignature = fields[3];
+            line = fields[4];
+        }
+
+        @Override
+        public String toString() {
+            return className + "." + methodName + "(" + source + ":" + line + ")";
+        }
+    }
+
+
 	
 
 }


### PR DESCRIPTION
Added file name to logged information and reporting locations using
the java Stack frame formatting.  If run in IDE (tested with Eclipse and IntelliJ) and the files in question are on the class path, then one can actually click on the provided locations similarly to visualizing stack traces locations.
