### PR TITLE
Cover cloudflare migration (FTP domain is now ftp.rv.com)

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -93,7 +93,7 @@
                         </goals>
                         <configuration>
                             <serverId>rv-site</serverId>
-                            <url>sftp://grigore@runtimeverification.com/</url>
+                            <url>sftp://grigore@ftp.runtimeverification.com/</url>
                             <fromDir>target/docs</fromDir>
                             <includes>**</includes>
                             <toDir>/home/grigore/public_html/runtimeverification.com/predict/${project.version}/docs</toDir>

--- a/rv-predict-installer/pom.xml
+++ b/rv-predict-installer/pom.xml
@@ -107,7 +107,7 @@
                         </goals>
                         <configuration>
                             <serverId>rv-site</serverId>
-                            <url>sftp://grigore@runtimeverification.com/</url>
+                            <url>sftp://grigore@ftp.runtimeverification.com/</url>
                             <fromDir>target</fromDir>
                             <includes>rv-predict-installer*.jar</includes>
                             <toDir>/home/grigore/public_html/runtimeverification.com/predict/${project.version}</toDir>


### PR DESCRIPTION
Self explanatory.  @dwightguth @traiansf @jeffhuanguiuc please review (one should be enough as this is a trivial change and can't break anything but deploy, which is already broken now).
