### PR TITLE
fixed Utility#isThreadClass to handle array properly

### DIFF
--- a/rv-predict-agent/src/main/java/rvpredict/instrumentation/Utility.java
+++ b/rv-predict-agent/src/main/java/rvpredict/instrumentation/Utility.java
@@ -168,6 +168,10 @@ public class Utility {
     }
 
     public static boolean isThreadClass(String className) {
+        if (className.startsWith(DESC_ARRAY_PREFIX)) {
+            return false;
+        }
+
         while (className != null && !className.equals("java/lang/Object")) {
             if (className.equals("java/lang/Thread")) {
                 return true;


### PR DESCRIPTION
This should fix the `ClassNotFound` exception from running the ftpserver example. Jeff used to suppress the `IOException` and that is why we didn't realize the problem.

Anyway, the root cause is that array is also treated as class in JVM but its internal name starts with `[`. And you can not use classloader to load from its internal name.

@traiansf please review
