### PR TITLE
fixed instrumentation for logging wait/notify/notifyAll

### DIFF
--- a/rv-predict-agent/src/main/java/rvpredict/instrumentation/SnoopInstructionMethodAdapter.java
+++ b/rv-predict-agent/src/main/java/rvpredict/instrumentation/SnoopInstructionMethodAdapter.java
@@ -110,14 +110,16 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor {
     @Override
     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
         if (opcode == INVOKEVIRTUAL) {
-            if (isThreadClass(owner)) {
-                if (desc.equals("()V")) {
-                    switch (name) {
-                    case "start":
+            if (desc.equals("()V")) {
+                switch (name) {
+                case "start":
+                    if (isThreadClass(owner)) {
                         prepareLoggingThreadEvents();
                         addLoggingCallBack(LOG_THREAD_START, DESC_LOG_THREAD_START);
-                        break;
-                    case "join":
+                    }
+                    break;
+                case "join":
+                    if (isThreadClass(owner)) {
                         /* TODO(YilongL): Since calls to thread join must be
                          * logged after they return, the code here is kind of
                          * ad-hoc. We definitely need more general way to handle
@@ -131,16 +133,16 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor {
                         addPushConstInsn(mv, sid);
                         mv.visitVarInsn(ALOAD, index);
                         addLoggingCallBack(LOG_THREAD_JOIN, DESC_LOG_THREAD_JOIN);
-                        return;
-                    case "wait":
-                        prepareLoggingThreadEvents();
-                        addLoggingCallBack(LOG_WAIT, DESC_LOG_WAIT);
-                        break;
-                    case "notify":
-                    case "notifyAll":
-                        prepareLoggingThreadEvents();
-                        addLoggingCallBack(LOG_NOTIFY, DESC_LOG_NOTIFY);
                     }
+                    return;
+                case "wait":
+                    prepareLoggingThreadEvents();
+                    addLoggingCallBack(LOG_WAIT, DESC_LOG_WAIT);
+                    break;
+                case "notify":
+                case "notifyAll":
+                    prepareLoggingThreadEvents();
+                    addLoggingCallBack(LOG_NOTIFY, DESC_LOG_NOTIFY);
                 }
             }
         }

--- a/rv-predict-agent/src/main/java/rvpredict/instrumentation/Utility.java
+++ b/rv-predict-agent/src/main/java/rvpredict/instrumentation/Utility.java
@@ -3,7 +3,6 @@ package rvpredict.instrumentation;
 import static org.objectweb.asm.Opcodes.*;
 
 import java.io.IOException;
-
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
@@ -182,7 +181,7 @@ public class Utility {
             try {
                 className = new ClassReader(className).getSuperName();
             } catch (IOException e) {
-                e.printStackTrace();
+                System.err.println("ASM ClassReader: unable to read " + className);
                 return false;
             }
         }


### PR DESCRIPTION
@traiansf please review

This should help reduce the exception stacktraces printed when running the Dacapo benchmark.
