### PR TITLE
Patch for Issue #337.

### DIFF
--- a/rv-predict-engine/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
+++ b/rv-predict-engine/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
@@ -114,10 +114,7 @@ public class Main {
             agentOptions.append(escapeString(arg)).append(" ");
         }
         if (!hasLogDir) {
-            agentOptions
-                    .append(Configuration.opt_only_log)
-                    .append(" ")
-                    .append(escapeString(config.outdir));
+            agentOptions.insert(0, Configuration.opt_only_log + " " + escapeString(config.outdir) + " ");
         }
         return agentOptions.toString();
     }
@@ -159,14 +156,15 @@ public class Main {
             appArgList.add("-cp");
             appArgList.add(rvEngine);
             appArgList.add(Main.class.getName());
+            int rvIndex = appArgList.size();
             appArgList.addAll(Arrays.asList(args));
 
             int index = appArgList.indexOf(Configuration.opt_outdir);
             if (index != -1) {
                 appArgList.set(index, Configuration.opt_only_predict);
             } else {
-                appArgList.add(Configuration.opt_only_predict);
-                appArgList.add(commandLine.outdir);
+                appArgList.add(rvIndex, Configuration.opt_only_predict);
+                appArgList.add(rvIndex+1, commandLine.outdir);
             }
 
             processBuilder = new ProcessBuilder(appArgList.toArray(args));


### PR DESCRIPTION
Because of the intricacies of argument handling, if no java options were specified, the class name was taken as part of the rv arguments.  This would have been fine (as the rv-predict command line parser accepts extra arguments at the end of the command.  However, this got further complicated by the fact that we append the --log /--predict option to the command line if not previously specified, which made the extra arguments not be at the end.  The resolution is to add --log /--predict at the beginning of the command,

@yilongli please review
