### PR TITLE
always clean the buffer to avoid ArrayIndexOutOfBoundsException when the...

### DIFF
--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/log/BufferedEventPipe.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/log/BufferedEventPipe.java
@@ -95,9 +95,15 @@ public class BufferedEventPipe implements EventPipe {
      */
     private synchronized void flush() throws InterruptedException {
         if (inIndex != 0) {
-            pipe.put(inBuffer);
-            inBuffer = new EventItem[BUFFER_SIZE+1];
-            inIndex = 0;
+            try {
+                pipe.put(inBuffer);
+            } catch (InterruptedException e) {
+                throw e;
+            } finally {
+                /* always clean the buffer to avoid ArrayIndexOutOfBoundsException */
+                inBuffer = new EventItem[BUFFER_SIZE+1];
+                inIndex = 0;
+            }
         }
     }
 


### PR DESCRIPTION
... logger thread is interrrupted

@traiansf please review
