### PR TITLE
Optimizing maven dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,44 +51,6 @@
             <url>http://office.runtimeverification.com:8888/repository/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.lmax</groupId>
-            <artifactId>disruptor</artifactId>
-            <version>3.3.2</version>
-        </dependency>
-        <dependency>
-	        <groupId>net.jpountz.lz4</groupId>
-	        <artifactId>lz4</artifactId>
-	        <version>1.3-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
     <build>
         <pluginManagement>
             <plugins>

--- a/rv-predict-agent/pom.xml
+++ b/rv-predict-agent/pom.xml
@@ -17,5 +17,16 @@
             <artifactId>rv-predict-engine</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rv-predict-engine/pom.xml
+++ b/rv-predict-engine/pom.xml
@@ -19,6 +19,12 @@
             <artifactId>rv-predict-logging</artifactId>
             <version>1.3-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/rv-predict-logging/pom.xml
+++ b/rv-predict-logging/pom.xml
@@ -22,6 +22,31 @@
             <artifactId>ant</artifactId>
             <version>1.8.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-all</artifactId>
+            <version>5.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>net.jpountz.lz4</groupId>
+            <artifactId>lz4</artifactId>
+            <version>1.3-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rv-predict/pom.xml
+++ b/rv-predict/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>docs</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
This should prevent the inclusion of rv-predict dependencies in examples.

@yilongli please review
