### PR TITLE
Update maven deploy infrastructure to new server information

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -79,7 +79,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Upload over SFTP during deploy phase -->
+            <!-- Upload over SCP during deploy phase -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>wagon-maven-plugin</artifactId>
@@ -93,10 +93,10 @@
                         </goals>
                         <configuration>
                             <serverId>rv-site</serverId>
-                            <url>sftp://grigore@ftp.runtimeverification.com/</url>
+                            <url>scp://grigore@ftp.runtimeverification.com/</url>
                             <fromDir>target/docs</fromDir>
                             <includes>**</includes>
-                            <toDir>/home/grigore/public_html/runtimeverification.com/predict/${project.version}/docs</toDir>
+                            <toDir>/var/www/predict/${project.version}/docs</toDir>
                         </configuration>
                     </execution>
                 </executions>

--- a/rv-predict-installer/pom.xml
+++ b/rv-predict-installer/pom.xml
@@ -107,10 +107,10 @@
                         </goals>
                         <configuration>
                             <serverId>rv-site</serverId>
-                            <url>sftp://grigore@ftp.runtimeverification.com/</url>
+                            <url>scp://grigore@ftp.runtimeverification.com/</url>
                             <fromDir>target</fromDir>
                             <includes>rv-predict-installer*.jar</includes>
-                            <toDir>/home/grigore/public_html/runtimeverification.com/predict/${project.version}</toDir>
+                            <toDir>/var/www/predict/${project.version}</toDir>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Until this is merged, no maven deploy jobs (either for master/snapshot or release) will be automatically uploaded to the rv.com website as with the previous build infrastructure.

Fairly simple change.
