### PR TITLE
fix constraint solving performance

### DIFF
--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/LockRegion.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/LockRegion.java
@@ -31,7 +31,7 @@ package com.runtimeverification.rvpredict.trace;
 import com.runtimeverification.rvpredict.log.Event;
 import com.runtimeverification.rvpredict.log.EventType;
 
-public class LockRegion {
+public class LockRegion implements Comparable<LockRegion> {
     private final Event lock;
     private final Event unlock;
 
@@ -90,6 +90,15 @@ public class LockRegion {
     @Override
     public String toString() {
         return String.format("<%s, %s>", lock, unlock);
+    }
+
+    @Override
+    public int compareTo(LockRegion otherRegion) {
+        long x1 = lock == null ? Integer.MIN_VALUE : lock.getGID();
+        long y1 = unlock == null ? Integer.MAX_VALUE : unlock.getGID();
+        long x2 = otherRegion.lock == null ? Integer.MIN_VALUE : otherRegion.lock.getGID();
+        long y2 = otherRegion.unlock == null ? Integer.MAX_VALUE : otherRegion.unlock.getGID();
+        return x1 != x2 ? Long.compare(x1, x2) : Long.compare(y1, y2);
     }
 
 }

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
@@ -443,13 +443,15 @@ public class Trace {
                         }
                     }
                 }
-
                 if (!events.isEmpty()) {
                     hasCriticalEvent = true;
                     tidToEvents.put(rawTrace.getTID(), events);
                     tidToMemoryAccessBlocks.put(rawTrace.getTID(), divideMemoryAccessBlocks(events));
                 }
             }
+
+            /* sort lock regions for better performance of constraint solving */
+            lockIdToLockRegions.values().forEach(regions -> Collections.sort(regions));
         }
     }
 


### PR DESCRIPTION
@traiansf please review

I just realize that constraint solving is much slower than in https://github.com/runtimeverification/rv-predict/pull/399. The problem is that I didn't sort the lock regions after switching to thread-local logging and the order of lock regions affect the solver's performance significantly.
