### PR TITLE
Fix dacapo

### DIFF
--- a/rv-predict-agent/src/main/java/com/runtimeverification/rvpredict/instrumentation/Agent.java
+++ b/rv-predict-agent/src/main/java/com/runtimeverification/rvpredict/instrumentation/Agent.java
@@ -112,15 +112,15 @@ public class Agent implements ClassFileTransformer, Constants {
     }
 
     private static void printStartupInfo() {
-        config.logger.reportPhase(Configuration.INSTRUMENTED_EXECUTION_TO_RECORD_THE_TRACE);
+        config.logger().reportPhase(Configuration.INSTRUMENTED_EXECUTION_TO_RECORD_THE_TRACE);
         if (config.getLogDir() != null) {
-            config.logger.report("Log directory: " + config.getLogDir(), Logger.MSGTYPE.INFO);
+            config.logger().report("Log directory: " + config.getLogDir(), Logger.MSGTYPE.INFO);
         }
         if (config.includes != null) {
-            config.logger.report("Including: " + config.includeList, Logger.MSGTYPE.INFO);
+            config.logger().report("Including: " + config.includeList, Logger.MSGTYPE.INFO);
         }
         if (config.excludes != null) {
-            config.logger.report("Excluding: " + config.excludeList, Logger.MSGTYPE.INFO);
+            config.logger().report("Excluding: " + config.excludeList, Logger.MSGTYPE.INFO);
         }
     }
 
@@ -165,9 +165,9 @@ public class Agent implements ClassFileTransformer, Constants {
             return null;
         } catch (Throwable e) {
             /* exceptions during class loading are silently suppressed by default */
-            System.err.println("Cannot retransform " + cname + ". Exception: " + e);
+            config.logger().debug().println("Cannot retransform " + cname + ". Exception: " + e);
             if (Configuration.debug) {
-                e.printStackTrace();
+                e.printStackTrace(config.logger().debug());
                 // fail-fast strategy under debug mode
                 System.exit(1);
             }

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/config/Configuration.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/config/Configuration.java
@@ -35,6 +35,7 @@ import com.runtimeverification.rvpredict.util.Constants;
 import com.runtimeverification.rvpredict.util.Logger;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
@@ -328,7 +329,7 @@ public class Configuration implements Constants {
 
     private static final String RVPREDICT_ARGS_TERMINATOR = "--";
 
-    public final Logger logger = new Logger();
+    private final Logger logger = new Logger();
 
     public static Configuration instance(String[] args) {
         Configuration config = new Configuration();
@@ -422,6 +423,15 @@ public class Configuration implements Constants {
                 System.exit(1);
             }
             prediction = offline ? OFFLINE_PREDICTION : ONLINE_PREDICTION;
+        }
+
+        if (log_dir != null) {
+            try {
+                logger.setLogDir(log_dir);
+            } catch (FileNotFoundException e) {
+                System.err.println("Error while attempting to create the logger.");
+                System.exit(1);
+            }
         }
 
         /* set window size */
@@ -531,6 +541,10 @@ public class Configuration implements Constants {
 
     public List<String> getJavaArguments() {
         return javaArgs;
+    }
+
+    public Logger logger() {
+        return logger;
     }
 
     /**

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
@@ -29,7 +29,7 @@ public class Main {
 
         if (config.isLogging() || config.isProfiling()) {
             if (config.getJavaArguments().isEmpty()) {
-                config.logger.report("You must provide a class or a jar to run.",
+                config.logger().report("You must provide a class or a jar to run.",
                         Logger.MSGTYPE.ERROR);
                 config.usage();
                 System.exit(1);
@@ -40,7 +40,7 @@ public class Main {
                 if (!outdirFile.exists()) {
                     outdirFile.mkdir();
                 } else  if (!outdirFile.isDirectory()) {
-                    config.logger.report(config.getLogDir() + " is not a directory",
+                    config.logger().report(config.getLogDir() + " is not a directory",
                             Logger.MSGTYPE.ERROR);
                     config.usage();
                     System.exit(1);

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/engine/main/RVPredict.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/engine/main/RVPredict.java
@@ -75,7 +75,7 @@ public class RVPredict {
             } while (trace.getSize() == config.windowSize);
 
             if (detector.getRaces().isEmpty()) {
-                config.logger.report("No races found.", Logger.MSGTYPE.INFO);
+                config.logger().report("No races found.", Logger.MSGTYPE.INFO);
             }
         } catch (IOException e) {
             System.err.println("Error: I/O error during prediction.");
@@ -98,7 +98,7 @@ public class RVPredict {
 
                 if (config.isOfflinePrediction()) {
                     if (config.isLogging()) {
-                        config.logger.reportPhase(Configuration.LOGGING_PHASE_COMPLETED);
+                        config.logger().reportPhase(Configuration.LOGGING_PHASE_COMPLETED);
                     }
 
                     Process process = null;

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/engine/main/RaceDetector.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/engine/main/RaceDetector.java
@@ -97,7 +97,7 @@ public class RaceDetector {
         result.forEach((sig, race) -> {
             String report = config.simple_report ? race.generateSimpleRaceReport() : race
                     .generateDetailedRaceReport();
-            config.logger.report(report, Logger.MSGTYPE.REAL);
+            config.logger().report(report, Logger.MSGTYPE.REAL);
         });
     }
 }

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/log/VolatileLoggingEngine.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/log/VolatileLoggingEngine.java
@@ -122,7 +122,7 @@ public class VolatileLoggingEngine implements ILoggingEngine, Constants {
         }
 
         if (detector.getRaces().isEmpty()) {
-            config.logger.report("No races found.", Logger.MSGTYPE.INFO);
+            config.logger().report("No races found.", Logger.MSGTYPE.INFO);
         }
     }
 
@@ -186,7 +186,7 @@ public class VolatileLoggingEngine implements ILoggingEngine, Constants {
             }
             detector.run(crntState.initNextTraceWindow(rawTraces));
         } catch (Throwable e) {
-            e.printStackTrace();
+            e.printStackTrace(config.logger().debug());
             /* cannot use System.exit because it may lead to deadlock */
             Runtime.getRuntime().halt(1);
         }

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/smt/MaximalCausalModel.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/smt/MaximalCausalModel.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.microsoft.z3.Context;
 import com.microsoft.z3.Params;
 import com.microsoft.z3.Status;
@@ -302,7 +303,7 @@ public class MaximalCausalModel {
             suspects.forEach(p -> suspectToAsst.computeIfAbsent(p, this::getRaceAssertion));
         });
         sigToRaceSuspects.entrySet().removeIf(e -> e.getValue().isEmpty());
-//        sigToRaceSuspects.forEach((sig, l) -> System.err.println(sig + ": " + l.size()));
+//        sigToRaceSuspects.forEach((sig, l) -> trace.logger().debug().println(sig + ": " + l.size()));
 
         Map<String, Race> result = new HashMap<>();
         Z3Filter z3filter = new Z3Filter(z3Context);

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
@@ -46,6 +46,7 @@ import com.runtimeverification.rvpredict.log.EventType;
 import com.runtimeverification.rvpredict.metadata.Metadata;
 import com.runtimeverification.rvpredict.trace.maps.MemoryAddrToObjectMap;
 import com.runtimeverification.rvpredict.trace.maps.MemoryAddrToStateMap;
+import com.runtimeverification.rvpredict.util.Logger;
 
 /**
  * Representation of the execution trace. Each event is created as a node with a
@@ -133,6 +134,10 @@ public class Trace {
             baseGID = min;
         }
         processEvents();
+    }
+
+    public Logger logger() {
+        return state.logger();
     }
 
     public Metadata metadata() {
@@ -384,6 +389,8 @@ public class Trace {
 
         /// PHASE 2
         if (!sharedAddr.isEmpty()) {
+//            logger().debug().println("start processing: " + baseGID);
+
             for (RawTrace rawTrace : rawTraces) {
                 /* step 1: remove thread-local events and nested lock events */
                 int tmp_size = 0;
@@ -466,7 +473,7 @@ public class Trace {
                 for (int i = 0; i < tmp_size; i++) {
                     if (critical[i]) {
                         Event event = tmp_events[i];
-//                        System.err.println(event + " at " + metadata().getLocationSig(event.getLocId()));
+//                        logger().debug().println(event + " at " + metadata().getLocationSig(event.getLocId()));
 
                         /* update tidToEvents & tidToAddrToWriteEvents */
                         events.add(event);

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/TraceState.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/TraceState.java
@@ -18,6 +18,7 @@ import com.runtimeverification.rvpredict.log.Event;
 import com.runtimeverification.rvpredict.metadata.Metadata;
 import com.runtimeverification.rvpredict.trace.maps.MemoryAddrToStateMap;
 import com.runtimeverification.rvpredict.trace.maps.ThreadIDToObjectMap;
+import com.runtimeverification.rvpredict.util.Logger;
 
 public class TraceState {
 
@@ -61,7 +62,10 @@ public class TraceState {
 
     private final Set<Event> t_clinitEvents;
 
+    private final Logger logger;
+
     public TraceState(Configuration config, Metadata metadata) {
+        this.logger = config.logger();
         this.metadata = metadata;
         this.t_tidToEvents             = new LinkedHashMap<>(DEFAULT_NUM_OF_THREADS);
         this.t_tidToMemoryAccessBlocks = new LinkedHashMap<>(DEFAULT_NUM_OF_THREADS);
@@ -71,6 +75,10 @@ public class TraceState {
                                             DEFAULT_NUM_OF_ADDR);
         this.t_lockIdToLockRegions     = new LinkedHashMap<>(config.windowSize >> 1);
         this.t_clinitEvents            = new HashSet<>(config.windowSize >> 1);
+    }
+
+    public Logger logger() {
+        return logger;
     }
 
     public Metadata metadata() {

--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/util/Logger.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/util/Logger.java
@@ -1,5 +1,10 @@
 package com.runtimeverification.rvpredict.util;
 
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+
 import com.google.common.base.Strings;
 
 /**
@@ -11,6 +16,13 @@ public class Logger {
     private static final int    WIDTH   =   75;
     private static final String DASH    =   "-";
 
+    private PrintStream debug = System.err;
+
+    public void setLogDir(String logDir) throws FileNotFoundException {
+        // TODO(YilongL): make sure this log file doesn't grow out of control
+        debug = new PrintStream(new FileOutputStream(Paths.get(logDir, "debug.log").toFile()));
+    }
+
     public void reportPhase(String phaseMsg) {
         report(center(phaseMsg), MSGTYPE.INFO);
     }
@@ -19,6 +31,10 @@ public class Logger {
         int fillWidth = WIDTH - msg.length();
         return "\n" + Strings.repeat(DASH, fillWidth / 2) + msg
                 + Strings.repeat(DASH, (fillWidth + 1) / 2);
+    }
+
+    public PrintStream debug() {
+        return debug;
     }
 
     public synchronized void report(String msg, MSGTYPE type) {


### PR DESCRIPTION
@traiansf please reivew

Using `System.err.` and `System.out` sometimes leads to deadlock when running DaCapo benchmark programs. I am not sure why though.
