### PR TITLE
temporary solution to avoid overflow of the ThreadIDToObject map

### DIFF
--- a/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/maps/ThreadIDToObjectMap.java
+++ b/rv-predict-logging/src/main/java/com/runtimeverification/rvpredict/trace/maps/ThreadIDToObjectMap.java
@@ -15,4 +15,13 @@ public final class ThreadIDToObjectMap<T> extends LongToObjectMap<T> {
         return (int) (key & mask);
     }
 
+    public static <T> ThreadIDToObjectMap<T> growOnFull(ThreadIDToObjectMap<T> map) {
+        if (map.size == map.capacity) {
+            ThreadIDToObjectMap<T> oldMap = map;
+            map = new ThreadIDToObjectMap<>(map.capacity << 1, map.newValue);
+            map.putAll(oldMap);
+        }
+        return map;
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/rv-predict/issues/429
