### PR TITLE
Add option to skip documentation to speed up Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,19 @@
     <artifactId>root</artifactId>
     <packaging>pom</packaging>
     <version>1.4-SNAPSHOT</version>
+    <profiles>
+        <profile>
+            <id>generate-docs</id>
+            <modules>
+                <module>docs</module>
+            </modules>
+            <activation>
+                <property>
+                    <name>!skipDocs</name>
+                </property>
+            </activation>
+        </profile>
+    </profiles>
     <modules>
         <module>rv-predict</module>
         <module>rv-predict-jar</module>
@@ -12,7 +25,6 @@
         <module>rv-predict-agent</module>
         <module>examples</module>
         <module>rv-predict-installer</module>
-        <module>docs</module>
     </modules>
     <url>http://www.runtimeverification.com</url>
     <scm>


### PR DESCRIPTION
Adds a new option, `-DskipDocs`, that can be added to Maven building to allow developers to skip the costly / slow process of building documentation when smoke testing simple fixes.

Now, developers can have a quick smoke test build with `mvn package -DskipTests -DskipDocs`.  This build completes in 35 seconds on my low powered laptop, with the majority of the build time spent in jarjar building jars.

We can also have skipping the docs be the default, by changing `!skipDocs` in this commit to something like `genDocs`.  Then, docs would never be generated unless `-DgenDocs` were passed as a Maven option (Jenkins would need to be modified accordingly of course).
