### PR TITLE
Fixing obfuscation problem

### DIFF
--- a/rv-predict-jar/proguard.conf
+++ b/rv-predict-jar/proguard.conf
@@ -7,6 +7,9 @@
   public static void main(java.lang.String[]);
 }
 
+# Proguard does not support yet polymorphic methods.Workaround: http://sourceforge.net/p/proguard/bugs/566/#aa62
+-dontwarn java.lang.invoke.MethodHandle
+
 -keep public class com.runtimeverification.rvpredict.engine.main.Main {
   public static void main(java.lang.String[]);
   static java.lang.String createAgentArgs(java.util.Collection);


### PR DESCRIPTION
Apparently it was introduced by using invoke, which is polymoprhic. 
However, Proguard does not support yet polymorphic methods.
Description of the bug and workaround:

http://sourceforge.net/p/proguard/bugs/566/#aa62
