### PR TITLE
Removing set-env from scripts (Windows).

### DIFF
--- a/rv-predict/src/main/scripts/bin/rv-predict-gui.bat
+++ b/rv-predict/src/main/scripts/bin/rv-predict-gui.bat
@@ -1,7 +1,6 @@
 @ECHO off
 SETLOCAL ENABLEEXTENSIONS
 IF ERRORLEVEL 1 ECHO Unable to enable extensions
-call "%~dp0\..\lib\setenv.bat"
 IF NOT DEFINED RV_OPTS SET RV_OPTS=-Xms64m -Xmx1024m -Xss32m
 SET RV_JAR=%~dp0..\lib\rv-predict.jar
 java %RV_OPTS% -jar "%RV_JAR%"

--- a/rv-predict/src/main/scripts/bin/rv-predict.bat
+++ b/rv-predict/src/main/scripts/bin/rv-predict.bat
@@ -1,7 +1,6 @@
 @ECHO off
 SETLOCAL ENABLEEXTENSIONS
 IF ERRORLEVEL 1 ECHO Unable to enable extensions
-call "%~dp0\..\lib\setenv.bat"
 IF NOT DEFINED RV_OPTS SET RV_OPTS=-Xms64m -Xmx1024m -Xss32m
 java %RV_OPTS% -ea -cp "%~dp0\..\lib\rv-predict.jar" com.runtimeverification.rvpredict.engine.main.Main %*
 ENDLOCAL


### PR DESCRIPTION
It was removed from lib a while back as we don't need any setup for windows machines anymore.

fixes #476 
