### PR TITLE
fix setenv script to work with source properly

### DIFF
--- a/rv-predict/src/main/scripts/lib/setenv
+++ b/rv-predict/src/main/scripts/lib/setenv
@@ -5,7 +5,7 @@ else
   ARCH=32;
 fi
 
-RV_PREDICT_LIB_DIR="$(cd $(dirname "$0")/../lib; pwd)"
+RV_PREDICT_LIB_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ `uname` = 'Darwin' ]; then
   export PATH="$RV_PREDICT_LIB_DIR/native/osx":$PATH
   export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:"$RV_PREDICT_LIB_DIR/native/osx"


### PR DESCRIPTION
@traiansf please review

The current setenv doesn't work with `source`. I follow the instructions in the documentation to source the setenv but `RV_PREDICT_LIB_DIR` is set to `/lib` instead of `<rvPath>/lib`.
