### PR TITLE
fixed user doc indentation

### DIFF
--- a/docs/src/docs/runningexamples.rst
+++ b/docs/src/docs/runningexamples.rst
@@ -60,7 +60,7 @@ To invoke RV-Predict on the Account class, simply replace
 
 If preferring RV-Predict's agent mode, the similar command would be:
 
- .. code-block:: none
+.. code-block:: none
 
     java -javaagent:<rvPath>/lib/rv-predict.jar -cp examples/examples.jar account.Account
 


### PR DESCRIPTION
@traiansf please review

The extra space at the beginning makes the command in the next line a block quote.
