### PR TITLE
Added tests for rv-predict-compile and fixed bug

### DIFF
--- a/bin/rv-predict-compile
+++ b/bin/rv-predict-compile
@@ -2,7 +2,7 @@
 
 
 cpp=0
-exts=(cc cp cxx cpp CPP c++ C)
+exts=("cc" "cp" "cxx" "cpp" "CPP" "c\+\+" "C")
 
 for i in "$@";
 do
@@ -12,6 +12,7 @@ do
         fi
     done
 done
+
 
 CMP=clang
 


### PR DESCRIPTION
@edgar-pek is this way of handling tests ok?
I was thinking maybe we could do something for C like it is for Java, automate compiling, executing and testing for source files. (the way it is currently handled is that there are pre-generated binary log files which are then fed into rv-predict)
