### PR TITLE
Fix for lock events not generating prelocks.

### DIFF
--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/deadlock/LockGraph.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/deadlock/LockGraph.java
@@ -35,7 +35,7 @@ public class LockGraph {
      * @param event  a lock/unlock event
      */
     public void handle(Event event) {
-        assert event.isPreLock() || event.isUnlock();
+        assert event.isPreLock() || event.isLock() || event.isUnlock();
         long lockId = event.getLockId();
         long tid = event.getTID();
         Set<Long> locks = lockSet.get(tid);
@@ -53,6 +53,7 @@ public class LockGraph {
             locks = new HashSet<>();
             lockSet.put(tid, locks);
         } else {
+            if (locks.contains(lockId)) return; // TODO(TraianSF): handle recursive locking
             locks.forEach(lock -> addEdge(lock, lockId));
         }
         locks.add(lockId);

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/TraceCache.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/TraceCache.java
@@ -99,7 +99,7 @@ public class TraceCache {
             do {
                 events.add(event);
                 //TODO(TraianSF): the following conditional does not belong here. Consider moving it.
-                if (event.isPreLock() || event.isUnlock()) {
+                if (event.isPreLock() || event.isLock() || event.isUnlock()) {
                     if (config.isLLVMPrediction()) {
                         //TODO(TraianSF): remove above condition once instrumentation works for Java
                         lockGraph.handle(event);


### PR DESCRIPTION
Since we do not generate PRE-LOCK events when handling atomic operations, I've updated the deadlock detection algorithm to consider both PRE-LOCK and LOCK operations.

I guest the better treatment would be to also have special UNLOCK events for deadlock detection, and use only those with PRE-LOCK events; this way we could handle recurrent locking by maintaining counters.

Therefore, this is only a temporary fix.

@edgar-pek please review
