### PR TITLE
update licensing version

### DIFF
--- a/rv-predict-installer/pom.xml
+++ b/rv-predict-installer/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.runtimeverification.licensing</groupId>
             <artifactId>rv-licensing</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>1.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.runtimeverification.rvpredict</groupId>


### PR DESCRIPTION
@traiansf please review

I made this change because I think there's something weird going on with the network on CentOS and I want to enable the wget fallback that we created for rv-predict-java.
