### PR TITLE
Make rv-predict-execute run "$@" instead of $1 so that I can pass par…

### DIFF
--- a/bin/rv-predict-execute
+++ b/bin/rv-predict-execute
@@ -1,6 +1,6 @@
 #!/bin/sh
 RVPREDICT=rv-predict
-$1
+"$@"
 #$RVPREDICT --window 64 --offline --llvm-predict .
 $RVPREDICT --offline --window 4000 --llvm-predict .
 rm *.bin *.txt *.log


### PR DESCRIPTION
…ameters to

a program run under RV-Predict analysis.