### PR TITLE
Display License Message

### DIFF
--- a/rv-predict-installer/pom.xml
+++ b/rv-predict-installer/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.runtimeverification.licensing</groupId>
             <artifactId>rv-licensing</artifactId>
-            <version>1.2-SNAPSHOT</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>com.runtimeverification.rvpredict</groupId>

--- a/rv-predict-source/pom.xml
+++ b/rv-predict-source/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>com.runtimeverification.licensing</groupId>
             <artifactId>rv-licensing</artifactId>
-            <version>[1.1-SNAPSHOT,)</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/config/Configuration.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/config/Configuration.java
@@ -55,6 +55,11 @@ import com.runtimeverification.licensing.Licensing;
  * Command line options class for rv-predict Used by JCommander to parse the
  * main program parameters.
  */
+/*
+ The descriptionKey argument to JCommander's Parameter annotation is abused to
+ specify a display order for options, instead of the indented purpose of localization.
+ If the last two digits are not '00' the option will be indented in the help list.
+ */
 public class Configuration implements Constants {
 
     public static final String LOGGING_PHASE_COMPLETED = "Logging phase completed.";
@@ -81,6 +86,8 @@ public class Configuration implements Constants {
             "/usr/bin/../lib/",	// TBD normalize paths, instead?
             "llvm/projects/compiler-rt"
     });
+
+    public static final String NO_LICENSE_ENV_VAR = "RVPREDICT_NO_LICENSE_MESSAGE";
 
     /**
      * Packages/classes that need to be excluded from instrumentation. These are
@@ -395,6 +402,12 @@ public class Configuration implements Constants {
     final static String opt_debug = "--debug";
     @Parameter(names = opt_debug, description = "Output developer debugging information", hidden = true, descriptionKey = "3000")
     public static boolean debug = false;
+
+    final static String no_license_message = "--no-license-message";
+    @Parameter(names = {no_license_message},
+            description = "Do not print a license message. Setting the the environment variable RVPREDICT_NO_LICENSE_MESSAGE has the same effect",
+            hidden = true, descriptionKey = "4000")
+    private boolean noLicenseMessage;
 
     final static String short_opt_verbose = "-v";
     final static String opt_verbose = "--verbose";
@@ -757,5 +770,13 @@ public class Configuration implements Constants {
 
     public boolean stacks() {
         return !nostacks;
+    }
+
+    public void logLicenseMessage(String licenseMessage) {
+        if (!noLicenseMessage
+                && !System.getenv().containsKey(Configuration.NO_LICENSE_ENV_VAR)
+                && !"".equals(licenseMessage)) {
+            logger().report(licenseMessage, Logger.MSGTYPE.INFO);
+        }
     }
 }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
@@ -9,8 +9,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+
+import com.runtimeverification.licensing.RVLicense;
 import com.runtimeverification.rvpredict.config.Configuration;
-import com.runtimeverification.rvpredict.instrument.Agent;
 import com.runtimeverification.rvpredict.util.Logger;
 
 import com.runtimeverification.licensing.Licensing;
@@ -28,9 +29,10 @@ public class Main {
      */
     public static void main(String[] args) {
         Licensing licensingSystem = new Licensing(Configuration.AGENT_RESOURCE_PATH, "predict");
-        licensingSystem.promptForLicense();
+        RVLicense license = licensingSystem.promptForLicense();
 
         config = Configuration.instance(args);
+        config.logLicenseMessage(license.getLicenseMessage());
 
         if (config.isLogging() || config.isProfiling()) {
             if (config.getJavaArguments().isEmpty()) {
@@ -63,7 +65,9 @@ public class Main {
 
         Process process = null;
         try {
-            process = new ProcessBuilder(args).start();
+            ProcessBuilder pb = new ProcessBuilder(args);
+            pb.environment().put(Configuration.NO_LICENSE_ENV_VAR, "");
+            process = pb.start();
             StreamGobbler errorGobbler = StreamGobbler.spawn(process.getErrorStream(), System.err);
             StreamGobbler outputGobbler = StreamGobbler.spawn(process.getInputStream(), System.out);
             StreamGobbler.spawn(System.in, new PrintStream(process.getOutputStream()), true /* flush */);

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/instrument/Agent.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/instrument/Agent.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.common.io.Resources;
+import com.runtimeverification.licensing.RVLicense;
 import com.runtimeverification.rvpredict.config.Configuration;
 import com.runtimeverification.rvpredict.engine.main.RVPredict;
 import com.runtimeverification.rvpredict.log.ILoggingEngine;
@@ -124,7 +125,10 @@ public class Agent implements ClassFileTransformer, Constants {
 
     private static void printStartupInfo() {
         Licensing licensingSystem = new Licensing(Configuration.AGENT_RESOURCE_PATH, "predict");
-        licensingSystem.promptForLicense();
+        RVLicense license = licensingSystem.promptForLicense();
+
+        config.logLicenseMessage(license.getLicenseMessage());
+
         config.logger().reportPhase(Configuration.INSTRUMENTED_EXECUTION_TO_RECORD_THE_TRACE);
         if (config.getLogDir() != null) {
             config.logger().report("Log directory: " + config.getLogDir(), Logger.MSGTYPE.INFO);


### PR DESCRIPTION
This increases the rv-licensing dependency to 1.3.1 to accept the
license format which may include a license message, and adds code
to display the message when appropriate.