### PR TITLE
Context implementation for reading the compact trace

### DIFF
--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEventFactory.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEventFactory.java
@@ -150,7 +150,7 @@ public class CompactEventFactory {
         });
     }
 
-    List<CompactEvent> exitSignal(Context context) {
+    List<CompactEvent> exitSignal(Context context) throws InvalidTraceDataException {
         long currentSignal = context.getSignalNumber();
         context.exitSignal();
         return Collections.singletonList(new CompactEvent(context, CompactEvent.Type.EXIT_SIGNAL) {
@@ -161,7 +161,8 @@ public class CompactEventFactory {
         });
     }
 
-    public List<CompactEvent> signalOutstandingDepth(Context context, int signalDepth) {
+    public List<CompactEvent> signalOutstandingDepth(Context context, int signalDepth)
+            throws InvalidTraceDataException {
         context.setSignalDepth(signalDepth);
         return NO_EVENTS;
     }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/NoDataReader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/NoDataReader.java
@@ -9,17 +9,20 @@ import com.runtimeverification.rvpredict.log.compact.TraceHeader;
 
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * This class should be used for aggregate data types that do not have any actual data besides the
  * delta-operation header, e.g. the thread end event.
  */
 public class NoDataReader implements CompactEventReader.Reader {
-    private final BiFunction<CompactEventFactory, Context, List<CompactEvent>> eventFactory;
+    @FunctionalInterface
+    public interface BiFunctionWithException<T, U, R> {
+        R apply(T t, U u) throws InvalidTraceDataException;
+    }
 
-    public NoDataReader(BiFunction<CompactEventFactory, Context, List<CompactEvent>> eventFactory) {
+    private final BiFunctionWithException<CompactEventFactory, Context, List<CompactEvent>> eventFactory;
+
+    public NoDataReader(BiFunctionWithException<CompactEventFactory, Context, List<CompactEvent>> eventFactory) {
         this.eventFactory = eventFactory;
     }
 

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/ContextTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/ContextTest.java
@@ -421,6 +421,13 @@ public class ContextTest {
         context.switchThread(SECOND_THREAD_ID);
 
         Assert.assertEquals(SECOND_THREAD_ID, context.getThreadId());
+        Assert.assertEquals(Context.INVALID_SIGNAL_NUMBER, context.getSignalNumber());
+        Assert.assertEquals(SECOND_GENERATION, context.getGeneration());
+        Assert.assertEquals(SECOND_PROGRAM_COUNTER, context.getPC());
+
+        context.setSignalDepth(1);
+
+        Assert.assertEquals(SECOND_THREAD_ID, context.getThreadId());
         Assert.assertEquals(SIGNAL_NUMBER, context.getSignalNumber());
         Assert.assertEquals(THIRD_GENERATION, context.getGeneration());
         Assert.assertEquals(THIRD_PROGRAM_COUNTER, context.getPC());


### PR DESCRIPTION
I still don't understand how signal masks work, so they are missing from the context. If what I believe about them is true, they shouldn't be handled in the context anyway.

There is still one more thing that I don't understand, i.e. how signal depth works when switching threads. There is one TODO about that in the Context.switchThread method: I would expect the ContextTest.signalNumberGenerationPCWhenSwitchingThreads test to pass, but it fails if the line below the TODO is not commented (I also had a question about it in an older e-mail, I'm also replying to that thread).