### PR TITLE
Fix issue #263 and maybe also #262.

### DIFF
--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/MappedByteBufferOutputStream.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/MappedByteBufferOutputStream.java
@@ -54,10 +54,10 @@ public class MappedByteBufferOutputStream extends OutputStream {
 
     private void grow() throws IOException {
         long remainingBytes = fileLen - filePos;
-        fileLen += nextChunkSize;
+        long nextBufferSize = Math.min(Integer.MAX_VALUE, nextChunkSize + remainingBytes);
+        fileLen += nextBufferSize - remainingBytes;
         file.setLength(fileLen);
-        buffer = file.getChannel().map(READ_WRITE, filePos,
-                Math.min(Integer.MAX_VALUE, nextChunkSize + remainingBytes));
+        buffer = file.getChannel().map(READ_WRITE, filePos, nextBufferSize);
         buffer.order(ByteOrder.nativeOrder());
         buffer.position(0);
         nextChunkSize = Math.min(Integer.MAX_VALUE, nextChunkSize << 1);


### PR DESCRIPTION
My rv-predict was outputting exceptions and stack traces, some of which seemed identical to the one in http://runtimeverification.com/support/predict/issues/263 . After this fix, all errors disappeared. I think that the stack trace in the issue above was caused by an exception in EventWriter.write, at this line:
out.write(byteBuffer.array());
which left the byteBuffer in a filled state, so it overflowed at the next write call.

I can only guess that this also fixes http://runtimeverification.com/support/predict/issues/263, but I have no way of checking that.