### PR TITLE
Simplify the Java compact trace metadata

### DIFF
--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/CompactMetadata.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/CompactMetadata.java
@@ -1,26 +1,16 @@
 package com.runtimeverification.rvpredict.metadata;
 
-import com.runtimeverification.rvpredict.config.Configuration;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CompactMetadata implements MetadataInterface {
-    private transient final ConcurrentHashMap<Long, String> addressToLocationSig = new ConcurrentHashMap<>();
     private final Map<Long, Pair<Long, Long>> otidToCreationInfo = new ConcurrentHashMap<>();
 
     @Override
     public String getLocationSig(long locationId) {
-        String sig = addressToLocationSig.get(locationId);
-        if (sig == null) {
-            if (Configuration.debug) {
-                System.err.println("getLocationSig("
-                        + locationId + " " + Long.toHexString(locationId) + ") -> null");
-            }
-            return String.format("0x%016x", locationId) + ";file:UNKNOWN;line:UNKNOWN";
-        }
-        return sig;
+        return String.format("{0x%016x}", locationId);
     }
 
     @Override
@@ -42,20 +32,11 @@ public class CompactMetadata implements MetadataInterface {
 
     @Override
     public String getVariableSig(long idx) {
-        return String.format("0x%016x", idx);
+        return String.format("[0x%016x]", idx);
     }
 
     @Override
     public boolean isVolatile(long addressForVolatileCheck) {
         return false;
-    }
-
-    public void setLocationSig(String signature) {
-        String[] signatureParts = signature.split(";");
-        String[] addressParts = signatureParts[0].split(":");
-        String addressString = addressParts[1];
-        assert addressString.startsWith("0x");
-        long address = Long.parseLong(addressString.substring(2), 16);
-        addressToLocationSig.put(address, signature);
     }
 }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/CompactTraceSignatureProcessor.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/CompactTraceSignatureProcessor.java
@@ -1,0 +1,8 @@
+package com.runtimeverification.rvpredict.metadata;
+
+public class CompactTraceSignatureProcessor extends SignatureProcessor {
+    @Override
+    public String simplify(String s) {
+        return s;
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/LLVMCompactTraceCache.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/LLVMCompactTraceCache.java
@@ -41,7 +41,7 @@ public class LLVMCompactTraceCache  extends TraceCache {
 
     private void parseLocInfo() throws IOException {
         parseInfo(
-                args -> metadata.setLocationSig((String)args[1]),
+                args -> {},
                 new BinaryReader(),
                 "loc");
     }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/violation/Race.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/violation/Race.java
@@ -31,6 +31,7 @@ package com.runtimeverification.rvpredict.violation;
 import com.google.common.base.StandardSystemProperty;
 import com.runtimeverification.rvpredict.config.Configuration;
 import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.metadata.CompactTraceSignatureProcessor;
 import com.runtimeverification.rvpredict.metadata.LLVMSignatureProcessor;
 import com.runtimeverification.rvpredict.metadata.MetadataInterface;
 import com.runtimeverification.rvpredict.metadata.SignatureProcessor;
@@ -69,7 +70,9 @@ public class Race {
         this.e2 = e2.copy();
         this.trace = trace;
         this.config = config;
-        if (config.isLLVMPrediction()) {
+        if (config.isCompactTrace()) {
+            this.signatureProcessor = new CompactTraceSignatureProcessor();
+        } else if (config.isLLVMPrediction()) {
             signatureProcessor = new LLVMSignatureProcessor();
         } else {
             signatureProcessor = new SignatureProcessor();
@@ -141,7 +144,7 @@ public class Race {
                 locSig = "field " + locSig;
         }
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("Data race on [%s]: %n", locSig));
+        sb.append(String.format("Data race on %s: %n", locSig));
         boolean reportableRace = false;
 
         if (trace.metadata().getLocationSig(e1.getLocationId())


### PR DESCRIPTION
I didn't do anything about thread information, so Java still reads some metadata.