### PR TITLE
Fix races involving atomic events.

### DIFF
--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/config/Configuration.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/config/Configuration.java
@@ -392,7 +392,7 @@ public class Configuration implements Constants {
     private String suppress = "";
 
     private final static String opt_detect_interrupted_thread_race = "--detect-interrupted-thread-race";
-    @Parameter(names = opt_detect_interrupted_thread_race, description = "Detect races between a data access event in a signal/interrupt and a data access event in the interrupted thread.")
+    @Parameter(names = opt_detect_interrupted_thread_race, description = "Detect races between a data access event in a signal/interrupt and a data access event in the interrupted thread.", descriptionKey = "2450")
     private boolean detectInterruptedThreadRace = true;
 
     /*

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/signals/EventsEnabledForSignalIterator.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/signals/EventsEnabledForSignalIterator.java
@@ -56,7 +56,7 @@ public class EventsEnabledForSignalIterator {
         }
         previousEvent = currentEvent;
         if (detectInterruptedThreadRace) {
-            findNextDisabledEvent();
+            findNextDisabledOrLockEvent();
         } else {
             advanceOneStep();
         }
@@ -76,9 +76,12 @@ public class EventsEnabledForSignalIterator {
         return true;
     }
 
-    private void findNextDisabledEvent() {
+    private void findNextDisabledOrLockEvent() {
         do {
             if (!advanceOneStep()) {
+                return;
+            }
+            if (currentEvent.isLock()) {
                 return;
             }
         } while (enabled);

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/smt/MaximalCausalModelTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/smt/MaximalCausalModelTest.java
@@ -1016,6 +1016,31 @@ public class MaximalCausalModelTest {
     }
 
     @Test
+    public void signalsDisabledByAtomicEvents() throws InvalidTraceDataException {
+        TraceUtils tu = new TraceUtils(mockContext, THREAD_1, NO_SIGNAL, BASE_PC);
+
+        List<ReadonlyEventInterface> e1;
+        List<ReadonlyEventInterface> e2;
+
+        List<RawTrace> rawTraces = Arrays.asList(
+                tu.createRawTrace(
+                        tu.nonAtomicStore(ADDRESS_1, VALUE_1),
+                        tu.enableSignal(SIGNAL_NUMBER_1),
+                        tu.atomicStore(ADDRESS_1, VALUE_2),
+                        e1 = tu.nonAtomicStore(ADDRESS_2, VALUE_2)),
+                tu.createRawTrace(
+                        tu.switchThread(THREAD_1, ONE_SIGNAL),
+                        tu.enterSignal(SIGNAL_NUMBER_1, SIGNAL_HANDLER_1, GENERATION_1),
+                        tu.atomicLoad(ADDRESS_1, VALUE_1),
+                        e2 = tu.nonAtomicStore(ADDRESS_2, VALUE_2)));
+
+        ReadonlyEventInterface event1 = extractSingleEvent(e1);
+        ReadonlyEventInterface event2 = extractSingleEvent(e2);
+
+        Assert.assertFalse(hasRace(rawTraces, event1, event2, true));
+    }
+
+    @Test
     public void raceWithSignalThatInterruptsSignal() throws InvalidTraceDataException {
         TraceUtils tu = new TraceUtils(mockContext, THREAD_1, NO_SIGNAL, BASE_PC);
 

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/TraceUtils.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/TraceUtils.java
@@ -148,6 +148,23 @@ public class TraceUtils {
                 CompactEventReader.Atomicity.NOT_ATOMIC);
     }
 
+    public List<ReadonlyEventInterface> atomicLoad(
+            long address, long value) throws InvalidTraceDataException {
+        prepareContextForEvent(threadId, signalDepth);
+        return compactEventFactory.dataManipulation(
+                mockContext, CompactEventReader.DataManipulationType.LOAD, LONG_SIZE_IN_BYTES,
+                address, value,
+                CompactEventReader.Atomicity.ATOMIC);
+    }
+
+    public List<ReadonlyEventInterface> atomicStore(long address, long value) throws InvalidTraceDataException {
+        prepareContextForEvent(threadId, signalDepth);
+        return compactEventFactory.dataManipulation(
+                mockContext, CompactEventReader.DataManipulationType.STORE, LONG_SIZE_IN_BYTES,
+                address, value,
+                CompactEventReader.Atomicity.ATOMIC);
+    }
+
     public static ReadonlyEventInterface extractSingleEvent(List<ReadonlyEventInterface> events) {
         Assert.assertEquals(1, events.size());
         return events.get(0);


### PR DESCRIPTION
I am not sure what should happen when a thread accesses an atomic variable, but the signal accesses the same address using a non-atomic variable. Should that generate a race? With the current code, this would be detected as a race.