### PR TITLE
Simpler faster.enterfn with callsite

### DIFF
--- a/doc/trace-spec
+++ b/doc/trace-spec
@@ -521,22 +521,29 @@ trace ::= (delta, 'load[n]') addr value
 
                 `self.PC <- self.PC + delta`
 
-        | (delta, 'enterfn') cfa
+        | (delta, 'enterfn') cfa callsite
 
                 The current thread added `delta` to its program counter
                 and entered a function at the new program counter.
                 The DWARF Canonical Frame Address (CFA) for the function's
                 new stack frame is given by the address `cfa`, which
-                begins on the first 32-bit boundary after the deltop;
-                it is `ptrw` bytes wide.
+                begins on the first 32-bit boundary after the deltop; it
+                is `ptrw` bytes wide.  In `callsite` is the instruction
+                where the just-entered function will return.  It is also
+                `ptrw` bytes wide, and it starts on the first 32-bit
+                boundary after `cfa`.
 
                 `self.PC <- self.PC + delta`
 
         | (delta, 'exitfn')
 
                 The current thread added `delta` to its program counter
-                and, at the new program counter, returned from the
-                current function.
+                and exited a function.  'enterfn' and 'exitfn' events
+                should form matched pairs: the value of the program
+                counter immediately after an 'enterfn' event should always
+                equal the program counter immediately after the matching
+                'exitfn' event.  Trace readers may reject a trace if it
+                does not display this property.
 
                 `self.PC <- self.PC + delta`
 
@@ -627,3 +634,10 @@ More changes:
 14) change the version number specification: it's 4 bytes, major / minor
     / teeny / tiny, not a 32-bit word.  Increase the current version
     number to 0.0.0.1.
+
+Change affecting function entry events:
+
+15) mention that 'enterfn' and 'exitfn' events form matched pairs with
+    the same PC after each event in a pair.
+
+16) add the `callsite` to the 'enterfn' event.

--- a/llvm/ngrt/func.c
+++ b/llvm/ngrt/func.c
@@ -3,7 +3,7 @@
 #include "trace.h"
 
 const void *
-__rvpredict_func_entry(const void *cfa)
+__rvpredict_func_entry(const void *cfa, const void *callsite)
 {
 	rvp_ring_t *r = rvp_ring_for_curthr();
 	rvp_buf_t b = RVP_BUF_INITIALIZER;
@@ -11,6 +11,7 @@ __rvpredict_func_entry(const void *cfa)
 
 	rvp_buf_put_pc_and_op(&b, &r->r_lastpc, retaddr, RVP_OP_ENTERFN);
 	rvp_buf_put_voidptr(&b, cfa);
+	rvp_buf_put_voidptr(&b, callsite);
 	rvp_ring_put_buf(r, b);
 
 	return retaddr;

--- a/llvm/ngrt/func.h
+++ b/llvm/ngrt/func.h
@@ -3,7 +3,7 @@
 #ifndef _RV_FUNC_H_
 #define _RV_FUNC_H_
 
-const void *__rvpredict_func_entry(const void *);
+const void *__rvpredict_func_entry(const void *, const void *);
 void __rvpredict_func_exit(const void *);
 
 #endif /* _RV_FUNC_H_ */

--- a/llvm/ngrt/trace.c
+++ b/llvm/ngrt/trace.c
@@ -23,7 +23,7 @@ typedef struct _threadswitch {
 
 static const rvp_trace_header_t header = {
 	  .th_magic = "RVP_"
-	, . th_version = {0, 0, 0, 2}
+	, . th_version = {0, 0, 0, 3}
 	, .th_byteorder = '0' | ('1' << 8) | ('2' << 16) | ('3' << 24)
 	, .th_pointer_width = sizeof(rvp_addr_t)
 	, .th_data_width = sizeof(uint32_t)

--- a/llvm/ngrt/tracefmt.h
+++ b/llvm/ngrt/tracefmt.h
@@ -205,6 +205,7 @@ typedef struct {
 typedef struct {
 	rvp_addr_t deltop;
 	rvp_addr_t cfa;
+	rvp_addr_t callsite;
 } __packed __aligned(sizeof(uint32_t)) rvp_enterfn_t;
 
 typedef struct {

--- a/llvm/pass/RVPredictInstrumentation.cpp
+++ b/llvm/pass/RVPredictInstrumentation.cpp
@@ -185,7 +185,7 @@ RVPredictInstrument::initializeCallbacks(Module &m)
 	 */
 	fnenter = checkSanitizerInterfaceFunction(
 	    m.getOrInsertFunction( "__rvpredict_func_entry",
-	        int8_ptr_type, int8_ptr_type, nullptr));
+	        int8_ptr_type, int8_ptr_type, int8_ptr_type, nullptr));
 	fnexit = checkSanitizerInterfaceFunction(
 	    m.getOrInsertFunction("__rvpredict_func_exit", void_type,
 	        int8_ptr_type, nullptr));
@@ -624,17 +624,16 @@ RVPredictInstrument::runOnFunction(Function &F)
         // instrumented accesses.
 	if ((didInstrument || hasCalls) && ClInstrumentFuncEntryExit) {
 		IRBuilder<> builder(F.getEntryBlock().getFirstNonPHI());
-#if 0
-		Value *retaddr = builder.CreateCall(
+		Value *callsite = builder.CreateCall(
 		    Intrinsic::getDeclaration(F.getParent(),
 		        Intrinsic::returnaddress),
 		    builder.getInt32(0));
-#endif
 		Value *cfa = builder.CreateCall(
 		    Intrinsic::getDeclaration(F.getParent(),
 		        Intrinsic::eh_dwarf_cfa),
 		    builder.getInt32(0));
-		CallInst *retaddr = builder.CreateCall(fnenter, cfa);
+		CallInst *retaddr = builder.CreateCall(fnenter,
+		    {cfa, callsite});
 		for (auto return_insn : RetVec) {
 			IRBuilder<> ret_builder(return_insn);
 			ret_builder.CreateCall(fnexit, retaddr);

--- a/llvm/rvpdump/reader.c
+++ b/llvm/rvpdump/reader.c
@@ -1120,13 +1120,15 @@ print_op(const rvp_pstate_t *ps, const rvp_ubuf_t *ub, rvp_op_t op,
 		    oi->oi_descr, ub->ub_cog.generation);
 		break;
 	case RVP_OP_ENTERFN:
-		printf("tid %" PRIu32 ".%" PRIu32 " %s %s cfa %" PRIxPTR "\n",
+		printf("tid %" PRIu32 ".%" PRIu32 " %s %s cfa %" PRIxPTR " return %s\n",
 		    ps->ps_curthread, ps->ps_idepth,
 		    (*emitters->insnptr_to_string)(ps, buf[0], sizeof(buf[0]),
 		        ps->ps_thread[ps->ps_curthread].
 			ts_lastpc[ps->ps_idepth]),
 		    oi->oi_descr,
-		    ub->ub_enterfn.cfa);
+		    ub->ub_enterfn.cfa,
+		    (*emitters->insnptr_to_string)(ps, buf[1], sizeof(buf[1]),
+		        ub->ub_enterfn.callsite));
 		break;
 	case RVP_OP_END:
 	default:
@@ -1382,7 +1384,7 @@ rvp_trace_dump(rvp_output_type_t otype, int fd)
 	 */
 	const rvp_trace_header_t expected_th = {
 		  .th_magic = "RVP_"
-		, .th_version = {0, 0, 0, 2}
+		, .th_version = {0, 0, 0, 3}
 		, .th_byteorder = '0' | ('1' << 8) | ('2' << 16) | ('3' << 24)
 		, .th_pointer_width = sizeof(rvp_addr_t)
 		, .th_data_width = sizeof(uint32_t)


### PR DESCRIPTION
Virgil,

Let me know how this works for you. I didn't make any changes to the analysis backend.

I was a bit surprised that the backend didn't fail immediately with a version number mismatch. Instead, it complained about a enter/exit-function mismatch.

This is a pretty typical change to the instrumentation pass and runtime, if you're curious how those are made. I always make a change to rvpdump and the documentation, too.

Let me know if doc/trace-spec is not clear.

Dave