### PR TITLE
Add an upper limit to the licensing version.

### DIFF
--- a/rv-predict-source/pom.xml
+++ b/rv-predict-source/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.runtimeverification.licensing</groupId>
             <artifactId>rv-licensing</artifactId>
-            <version>[1.1-SNAPSHOT,)</version>
+            <version>[1.1-SNAPSHOT,1.4)</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>


### PR DESCRIPTION
Without this pull request, https://github.com/runtimeverification/rv-licensing/pull/7 would break the simpler-faster branch.