### PR TITLE
Add support for a binary output format, -t binary, and a limit to the

### DIFF
--- a/llvm/rvpdump/reader.h
+++ b/llvm/rvpdump/reader.h
@@ -4,12 +4,14 @@
 typedef enum _rvp_output_type {
 	  RVP_OUTPUT_PLAIN_TEXT = 0
 	, RVP_OUTPUT_SYMBOL_FRIENDLY
+	, RVP_OUTPUT_BINARY
 	, RVP_OUTPUT_LEGACY_BINARY
 } rvp_output_type_t;
 
 typedef struct _rvp_output_params {
 	rvp_output_type_t	op_type;
 	bool			op_emit_generation;
+	size_t			op_nrecords;
 } rvp_output_params_t;
 
 void rvp_trace_dump(const rvp_output_params_t *, int);


### PR DESCRIPTION
number of trace records emitted, -n #traces.  The limit can be used with
any of the output formats.

'rvpdump -t binary -n 500' behaves sort of like the UNIX head(1) command
on an RV-Predict/C trace file: it copies the header and first 500 records
(or all records, if there are fewer than 500) to stdout.