### PR TITLE
Fix the most obvious rv-predict installer issues.

### DIFF
--- a/c-install/pom.xml
+++ b/c-install/pom.xml
@@ -52,7 +52,7 @@
                                 <artifactItem>
                                     <groupId>com.runtimeverification.install</groupId>
                                     <artifactId>rv-install</artifactId>
-                                    <version>1.1-SNAPSHOT</version>
+                                    <version>1.5-SNAPSHOT</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${staging.dir.app}</outputDirectory>

--- a/c-install/src/main/izpack/install.xml
+++ b/c-install/src/main/izpack/install.xml
@@ -86,11 +86,11 @@
                 <exclude name="rv-predict" />
                 <os family="unix"/>
             </fileset>
+            <executable os="unix" targetfile="$INSTALL_PATH/bin/rvpa" type="bin" keep="true" stage="never"/>
             <executable os="unix" targetfile="$INSTALL_PATH/bin/rvpc" type="bin" keep="true" stage="never"/>
             <executable os="unix" targetfile="$INSTALL_PATH/bin/rvpc++" type="bin" keep="true" stage="never"/>
-            <executable os="unix" targetfile="$INSTALL_PATH/bin/rvpdump" type="bin" keep="true" stage="never"/>
+            <executable os="unix" targetfile="$INSTALL_PATH/bin/rvplicense" type="bin" keep="true" stage="never"/>
             <executable os="unix" targetfile="$INSTALL_PATH/bin/rvpsymbolize" type="bin" keep="true" stage="never"/>
-            <executable os="unix" targetfile="$INSTALL_PATH/bin/rvsyms" type="bin" keep="true" stage="never"/>
             <executable os="unix" targetfile="$INSTALL_PATH/bin/rvpx" type="bin" keep="true" stage="never"/>
             <fileset dir="lib" targetdir="$INSTALL_PATH/lib">
 		<exclude name="libclang_rt.*"/>

--- a/rv-predict-installer/pom.xml
+++ b/rv-predict-installer/pom.xml
@@ -52,7 +52,7 @@
                                 <artifactItem>
                                     <groupId>com.runtimeverification.install</groupId>
                                     <artifactId>rv-install</artifactId>
-                                    <version>1.1-SNAPSHOT</version>
+                                    <version>1.5-SNAPSHOT</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>../target/release/rv-predict/</outputDirectory>

--- a/rv-predict-installer/src/main/izpack/install.xml
+++ b/rv-predict-installer/src/main/izpack/install.xml
@@ -73,7 +73,9 @@
                 <os family="windows"/>
             </fileset>
             <fileset dir="bin" targetdir="$INSTALL_PATH/bin">
-                <exclude name="*.bat" />
+                <include name="checkJava" />
+                <include name="rvplicense" />
+                <include name="rv-predict" />
                 <os family="unix"/>
             </fileset>
             <fileset dir="lib/native/windows32" targetdir="$INSTALL_PATH/bin">
@@ -82,6 +84,9 @@
             <fileset dir="lib/native/windows64" targetdir="$INSTALL_PATH/bin">
                 <os family="windows" arch="amd64"/>
             </fileset>
+            <executable os="unix" targetfile="$INSTALL_PATH/bin/checkJava" type="bin" keep="true" stage="never"/>
+            <executable os="unix" targetfile="$INSTALL_PATH/bin/rvplicense" type="bin" keep="true" stage="never"/>
+            <executable os="unix" targetfile="$INSTALL_PATH/bin/rv-predict" type="bin" keep="true" stage="never"/>
         </pack>
         <pack name="Examples" required="no" installGroups="New Application" >
             <description>Example Java programs illustrating RV-Predict's features.</description>


### PR DESCRIPTION
* Stop setting the executable bit for files that do not exist.
* Upgrade the licensing version.
* Removed C-specific files from the Java installer and set the executable bit for the remaining ones.

One obvious issue remaining is that the installer UI is broken-ish on HDPI displays under Linux, but, most likely, that's hard to fix.