### PR TITLE
Fixes for the c installer.

### DIFF
--- a/c-install/res/izpack-rv-predict-eng-lang.xml
+++ b/c-install/res/izpack-rv-predict-eng-lang.xml
@@ -10,7 +10,7 @@
     <str id="DependencyPanel.headline" txt="Dependencies" />
     <str id="PacksPanel.headline" txt="Packages" />
 
-    <str id="InstallPanel.headline" txt="Copying temporary files"/>
+    <str id="InstallPanel.headline" txt="Copy temporary files"/>
     <str id="InstallPanel.tip" txt="Overall progress"/>
     <str id="InstallPanel.progress" txt="Packages progress"/>
 

--- a/c-install/res/rvdependencies/rv-predict-finish.html
+++ b/c-install/res/rvdependencies/rv-predict-finish.html
@@ -1,6 +1,12 @@
 <html>
     <h3> Successfully installed $APP_NAME </h3><hr><br><br>
-    See ${INSTALL_PATH}${FILE_SEPARATOR}README.md for instructions on getting started.
+    <!-- TODO(virgil): The path to this file should be the output of something like
+
+         mkcmake PREFIX=/usr -C doc -V '${FILESDIR}'
+
+         Right now it seems that one can't compute that in install.xml, it should be sent
+         from Maven, and, most likely, one needs to write a plugin for that. -->
+    See /usr/share/doc/rv-predict-c/USERS-MANUAL.md for instructions on getting started.
     <br><br>
     To uninstall, please run<br>
     sudo dpkg -r rv-predict-c

--- a/c-install/scripts/install-package.sh
+++ b/c-install/scripts/install-package.sh
@@ -5,5 +5,9 @@ set -e
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
+echo 'y' | dpkg -i "$SCRIPTPATH/../rv-predict-c-$1.deb" || apt-get install -f -y
 echo 'y' | dpkg -i "$SCRIPTPATH/../rv-predict-c-$1.deb"
-apt-get install -f
+
+echo
+echo
+echo "Installation finished succesfully."

--- a/c-install/src/main/izpack/install.xml
+++ b/c-install/src/main/izpack/install.xml
@@ -12,6 +12,7 @@
         <uninstaller write="no"/>
         <writeinstallationinformation>false</writeinstallationinformation>
         <run-privileged condition="izpack.linuxinstall|izpack.windowsinstall|izpack.macinstall"/>
+        <tempdir variablename="INSTALL_PATH"/>
     </info>
 
     <variables>
@@ -49,10 +50,19 @@
 <!--        <res id="TargetPanel.dir.windows" src="res/windows-installpath.txt"/> -->
     </resources>
 
+    <conditions>
+        <condition type="comparenumerics" id="false">
+            <arg1>1</arg1>
+            <arg2>2</arg2>
+            <operator>eq</operator>
+        </condition>
+    </conditions>
+
     <!-- Installer Panel Sequence -->
     <panels>
-        <!-- TODO(virgil): Is there a point in asking the user about the temp directory? Most likely not. -->
-        <panel classname="TargetPanel"/>
+        <!-- There is a long-standing izpack problem that a TargetPanel is required. We don't need one,
+             so we're filtering it out using a condition -->
+        <panel classname="TargetPanel" id="targetPanelId" condition="false"/>
         <!-- Check RV key and make sure it validates properly -->
         <panel classname="UserInputPanel" id="rvkey">
             <validator classname="com.izforge.izpack.panels.rvkey.RVKeyValidator"/>


### PR DESCRIPTION
* Disabled the path selection panel.

* Fixed the README file path and added TODO to compute it properly.

* Fixed the installer to not fail when the first dpkg command reports missing dependencies.

* Added "Installation successfull" message in the console box.