### PR TITLE
Shared library support for rv-predict.

### DIFF
--- a/doc/trace-spec
+++ b/doc/trace-spec
@@ -126,6 +126,8 @@ Right now I have in mind just 28 opcodes, which I assign these numbers:
 	unblock-sigs	43	// remove signals from the current mask
 	sig-getset-mask	44	// get old mask, set new mask
 	sig-get-mask	45	// get old mask
+        shared-library  46      // shared library data
+        shared-library-segment 47  // a shared library's segment
 
 The first trace helps the reader to establish an important fact that
 lets it interpret the following traces: PC = (0, begin).  That
@@ -605,6 +607,32 @@ trace ::= (delta, 'load[n]') addr value
                 `self.PC <- self.PC + delta`
                 `self <- tid`
 		`self.signal_depth <- 0`
+
+        | (delta, 'shared-library') libid namelen namechars
+
+                The current thread added `delta` to its program counter.
+                The program used a library with the given name.
+
+                `libid` begins on the first 32-bit boundary after the
+                deltop, and it is 32 bits wide.
+
+                `namelen` begins after `libid` and it is 32 bits wide.
+
+                `namechars` is an ASCII encoding of the library name. It
+                begins after `namelen` and it has `namelen` bytes, with 
+                padding added at the end to fill up to a 32 bit boundary. 
+
+        | (delta, 'shared-library-segment') libid start size
+
+                The current thread added `delta` to its program counter.
+                The library with id `libid` had a segment of `size` bytes,
+                starting at the `start` pointer.
+
+                `libid` begins on the first 32-bit boundary after the
+                deltop, and it is 32 bits wide.
+
+                `start` has the size of a pointer, while `size` is 32 bit
+                wide.
 
 # History
 

--- a/errors/rv-error/README.md
+++ b/errors/rv-error/README.md
@@ -8,7 +8,7 @@ opam init
 opam update
 opam switch 4.03.0
 eval `opam config env`
-opam install ocp-ocamlres ocamlbuild-atdgen csv uri atdgen
+opam install ocp-ocamlres ocamlbuild-atdgen csv uri atdgen atdj
 ```
 
 ## Description

--- a/llvm/README
+++ b/llvm/README
@@ -10,16 +10,13 @@ BUILDING
 
 To build both the runtime and the instrumentation pass:
 
-	mkdir build
-	cd build
-	cmake ..
-	make
+    mkcmake PREFIX=$HOME install
 
-After you run make, the two binaries that you need to add RV-Predict
-instrumentation to your program are under build/,
+After you run mkcmake, the two binaries that you need to add RV-Predict
+instrumentation to your program are under $HOME/lib,
 
-	pass/rvpinstrument.so
-	runtime/lib/linux/libclang_rt.tsan-x86_64.a
+	$HOME/lib/rvpinstrument.so
+	$HOME/lib/librvprt.a
 
 The LLVM installation on office.runtimeverification.com:2222 is screwed
 up, so I recommend fetching and extracting a CLang+LLVM pre-built binary
@@ -29,19 +26,18 @@ run cmake like so:
 
 	cmake -DLLVM_DIR=$HOME/clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04/share/llvm/cmake ..
 
-USING
 
 To compile your program with RV-Predict instrumentation, follow these
-steps, where $BUILD refers to the build directory, build/, above,
+steps, where $BUILD refers to the $HOME/lib directory above,
 $SRCS refers to your source files, $OBJS to the object files created
 from those sources, and $PROG is the program you are building:
 
 Compile each source file, $src in $SRCS:
 
-	clang -g -Xclang -load -Xclang $BUILD/pass/rvpinstrument.so -c $src
+	clang -g -Xclang -load -Xclang $BUILD/rvpinstrument.so -c $src
 
 Link:
 
 	clang     -o $PROG $OBJS \
-	    -L$BUILD/runtime/lib/linux -lclang_rt.tsan-x86_64 -ldl -lrt -pthread -g
+	    -L$BUILD/lib -lrvprt -ldl -lrt -pthread -g
 

--- a/llvm/ngrt/Makefile
+++ b/llvm/ngrt/Makefile
@@ -21,6 +21,7 @@ SRCS+=register.c relay.c ring.c rmw.c rvpsignal.c sigutil.c
 SRCS+=supervise.c
 SRCS+=thread.c trace.c
 SRCS+=intr.c
+SRCS+=dynamic_library.c
 WARNS=4
 
 .include <mkc.lib.mk>

--- a/llvm/ngrt/buf.h
+++ b/llvm/ngrt/buf.h
@@ -3,26 +3,47 @@
 
 #include <assert.h>
 #include <stdint.h>	/* for uint32_t */
+#include <string.h>
 
 #include "nbcompat.h"	/* for __arraycount() */
 #include "tracefmt.h"	/* for rvp_op_t */
 
 typedef struct {
 	unsigned int b_nwords;
-	uint32_t b_word[12];
-} rvp_buf_t;
+	uint32_t b_word[];
+} rvp_generic_buf_t;
 
-#define RVP_BUF_INITIALIZER	(rvp_buf_t){ .b_nwords = 0 }
+static rvp_generic_buf_t rvp_generic_buf_t_example;
+
+// The type for a rvp_generic_buf_t with 'capacity' entries in the buffer.
+#define RVP_BUF_TYPE(capacity) \
+union { \
+	rvp_generic_buf_t buf; \
+	char filler[sizeof(rvp_generic_buf_t) + \
+	    (capacity) * sizeof(rvp_generic_buf_t_example.b_word[0])]; \
+}
+
+typedef RVP_BUF_TYPE(12) rvp_buf_t;
+
+#define RVP_BUF_GENERIC_INITIALIZER(type)	(type){ .buf.b_nwords = 0 }
+#define RVP_BUF_INITIALIZER	RVP_BUF_GENERIC_INITIALIZER(rvp_buf_t)
+
+#define RVP_BUF_CAPACITY(b) \
+	((__arraycount((b).filler) - sizeof(rvp_generic_buf_t)) \
+		/ sizeof((b).buf.b_word[0]))
 
 static inline void
-rvp_buf_put(rvp_buf_t *b, uint32_t item)
+rvp_buf_generic_put(rvp_generic_buf_t *b, uint32_t item, unsigned int capacity)
 {
-	assert(b->b_nwords < __arraycount(b->b_word));
+	assert(b->b_nwords < capacity);
 	b->b_word[b->b_nwords++] = item;
 }
 
+#define rvp_buf_put(b, item) \
+rvp_buf_generic_put(&((b)->buf), item, RVP_BUF_CAPACITY(*(b)))
+
 static inline void
-rvp_buf_put_addr(rvp_buf_t *b, rvp_addr_t addr)
+rvp_buf_generic_put_addr(rvp_generic_buf_t *b, rvp_addr_t addr, unsigned int capacity)
 {
 	unsigned int i;
 	union {
@@ -31,27 +52,65 @@ rvp_buf_put_addr(rvp_buf_t *b, rvp_addr_t addr)
 	} addru = {.uaddr = addr};
 
 	for (i = 0; i < __arraycount(addru.u32); i++) {
-		rvp_buf_put(b, addru.u32[i]);
+		rvp_buf_generic_put(b, addru.u32[i], capacity);
 	}
 }
 
-static inline void
-rvp_buf_put_voidptr(rvp_buf_t *b, const void *addr)
-{
-	rvp_buf_put_addr(b, (rvp_addr_t)addr);
-}
+#define rvp_buf_put_addr(b, item) \
+rvp_buf_generic_put_addr(&((b)->buf), item, RVP_BUF_CAPACITY(*(b)))
 
 static inline void
-rvp_buf_put_u64(rvp_buf_t *b, uint64_t val)
+rvp_buf_generic_put_voidptr(rvp_generic_buf_t *b, const void *addr, unsigned int capacity)
+{
+	rvp_buf_generic_put_addr(b, (rvp_addr_t)addr, capacity);
+}
+
+#define rvp_buf_put_voidptr(b, item) \
+rvp_buf_generic_put_voidptr(&((b)->buf), item, RVP_BUF_CAPACITY(*(b)))
+
+static inline void
+rvp_buf_generic_put_u64(rvp_generic_buf_t *b, uint64_t val, unsigned int capacity)
 {
 	union {
 		uint64_t u64;
 		uint32_t u32[2];
 	} valu = {.u64 = val};
 
-	rvp_buf_put(b, valu.u32[0]);
-	rvp_buf_put(b, valu.u32[1]);
+	rvp_buf_generic_put(b, valu.u32[0], capacity);
+	rvp_buf_generic_put(b, valu.u32[1], capacity);
 }
+
+#define rvp_buf_put_u64(b, item) \
+rvp_buf_generic_put_u64(&((b)->buf), item, RVP_BUF_CAPACITY(*(b)))
+
+static inline void
+rvp_buf_generic_put_string(rvp_generic_buf_t *b, const char* str, unsigned int capacity)
+{
+	union {
+		uint32_t u32;
+		char c[4];
+	} value = {.u32 = 0};
+	int filled = 0;
+
+	rvp_buf_generic_put(b, strlen(str), capacity);
+
+	for (; *str; str++) {
+		value.c[filled] = *str;
+		if (filled == 3) {
+			filled = 0;
+			rvp_buf_generic_put(b, value.u32, capacity);
+			value.u32 = 0;
+		} else {
+			filled++;
+		}
+	}
+	if (filled > 0) {
+		rvp_buf_generic_put(b, value.u32, capacity);
+	}
+}
+
+#define rvp_buf_put_string(b, item) \
+rvp_buf_generic_put_string(&((b)->buf), item, RVP_BUF_CAPACITY(*(b)))
 
 void rvp_buf_put_pc_and_op(rvp_buf_t *, const char **, const char *, rvp_op_t);
 void rvp_buf_put_cog(rvp_buf_t *, uint64_t);

--- a/llvm/ngrt/dynamic_library.c
+++ b/llvm/ngrt/dynamic_library.c
@@ -1,0 +1,54 @@
+#include <link.h>
+
+#include "buf.h"
+#include "ring.h"
+#include "thread.h"
+#include "trace.h"
+
+typedef RVP_BUF_TYPE(12 + PATH_MAX) rvp_buf_with_one_path_t;
+
+#define RVP_BUF_WITH_ONE_PATH_INITIALIZER \
+RVP_BUF_GENERIC_INITIALIZER(rvp_buf_with_one_path_t)
+
+static uint32_t shared_library_count = 0;
+
+static int
+log_shared_library(struct dl_phdr_info *info, size_t size, void *data)
+{
+	rvp_ring_t *r = rvp_ring_for_curthr();
+	rvp_buf_with_one_path_t b_library = RVP_BUF_WITH_ONE_PATH_INITIALIZER;
+
+	int j;
+	uint32_t this_library_id = shared_library_count;
+	shared_library_count++;
+
+	rvp_buf_put_voidptr(
+		&b_library, rvp_vec_and_op_to_deltop(0, RVP_OP_SHARED_LIBRARY));
+	
+	rvp_buf_put(&b_library, this_library_id);  // library_id
+	rvp_buf_put_string(&b_library, info->dlpi_name);
+	rvp_ring_put_buf(r, b_library);
+
+	for (j = 0; j < info->dlpi_phnum; j++) {
+		// TODO(virgil): filter out segments that are not interesting, e.g. by
+		// looking at info->dlpi_phdr[j].p_type.
+		void* addr = (void *)(info->dlpi_addr + info->dlpi_phdr[j].p_vaddr);
+		Elf32_Word size = info->dlpi_phdr[j].p_memsz;
+		rvp_buf_t b_segment = RVP_BUF_INITIALIZER;
+
+		rvp_ring_t *r = rvp_ring_for_curthr();
+		rvp_buf_put_pc_and_op(
+			&b_segment, &r->r_lastpc, r->r_lastpc, RVP_OP_SHARED_LIBRARY_SEGMENT);
+		rvp_buf_put(&b_segment, this_library_id);
+		rvp_buf_put_voidptr(&b_segment, addr);
+		rvp_buf_put(&b_segment, size);
+		rvp_ring_put_buf(r, b_segment);
+	}
+
+	return 0;
+}
+
+void rvpredict_log_shared_libraries()
+{
+	dl_iterate_phdr(log_shared_library, NULL);
+}

--- a/llvm/ngrt/dynamic_library.h
+++ b/llvm/ngrt/dynamic_library.h
@@ -1,0 +1,6 @@
+#ifndef _RVP_DYNAMIC_LIBRARY_H_
+#define _RVP_DYNAMIC_LIBRARY_H_
+
+void rvpredict_log_shared_libraries();
+
+#endif  // _RVP_DYNAMIC_LIBRARY_H_

--- a/llvm/ngrt/ring.c
+++ b/llvm/ngrt/ring.c
@@ -50,11 +50,11 @@ rvp_ring_init(rvp_ring_t *r, uint32_t *items, size_t nitems)
 int
 rvp_ring_stdinit(rvp_ring_t *r)
 {
-	const size_t ringsz = pgsz;
+	const size_t ringsz = ((2 * PATH_MAX) / pgsz + 1) * pgsz;
 	const size_t items_per_ring = ringsz / sizeof(*r->r_items);
 	uint32_t *items;
 
-	assert(pgsz != 0);
+	assert(ringsz != 0);
 
 	items = calloc(items_per_ring, sizeof(*r->r_items));
 	if (items == NULL)

--- a/llvm/ngrt/ring.h
+++ b/llvm/ngrt/ring.h
@@ -356,10 +356,11 @@ rvp_ring_put_multiple(rvp_ring_t *r, const uint32_t *item, int nitems)
 }
 
 static inline void
-rvp_ring_put_buf(rvp_ring_t *r, rvp_buf_t b)
+rvp_ring_generic_put_buf(rvp_ring_t *r, rvp_generic_buf_t *b)
 {
-	rvp_ring_put_multiple(r, &b.b_word[0], b.b_nwords);
+       rvp_ring_put_multiple(r, &b->b_word[0], b->b_nwords);
 }
+#define rvp_ring_put_buf(r, b) rvp_ring_generic_put_buf(r, &b.buf)
 
 /* Return `true` if the interruption is unfinished, false otherwise. */
 static inline bool

--- a/llvm/ngrt/thread.c
+++ b/llvm/ngrt/thread.c
@@ -12,6 +12,7 @@
 #include <string.h> /* for strerror(3), strcasecmp(3) */
 #include <unistd.h> /* for sysconf */
 
+#include "dynamic_library.h"
 #include "init.h"
 #include "interpose.h"
 #include "relay.h"
@@ -339,6 +340,7 @@ rvp_postfork_init(void)
 	 * to start.
 	 */
 	rvp_thread0_create();
+	rvpredict_log_shared_libraries();
 	rvp_relay_create();
 	rvp_serializer_create();
 

--- a/llvm/ngrt/trace.c
+++ b/llvm/ngrt/trace.c
@@ -23,7 +23,7 @@ typedef struct _threadswitch {
 
 static const rvp_trace_header_t header = {
 	  .th_magic = "RVP_"
-	, . th_version = {0, 0, 0, 3}
+	, . th_version = {0, 0, 0, 4}
 	, .th_byteorder = '0' | ('1' << 8) | ('2' << 16) | ('3' << 24)
 	, .th_pointer_width = sizeof(rvp_addr_t)
 	, .th_data_width = sizeof(uint32_t)

--- a/llvm/ngrt/tracefmt.h
+++ b/llvm/ngrt/tracefmt.h
@@ -92,6 +92,9 @@ typedef enum _rvp_op {
 	, RVP_OP_SIGUNBLOCK	= 43	// unblock signals
 	, RVP_OP_SIGGETSETMASK	= 44	// get old mask, set new mask
 	, RVP_OP_SIGGETMASK	= 45	// get current mask
+	, RVP_OP_SHARED_LIBRARY = 46  // sets data for a shared library.
+	, RVP_OP_SHARED_LIBRARY_SEGMENT = 47  // data for a segment belonging
+	                                      // to a shared library.
 	, RVP_NOPS
 } rvp_op_t;
 
@@ -216,5 +219,19 @@ typedef struct {
 	rvp_addr_t deltop;
 	rvp_addr_t addr;
 } __packed __aligned(sizeof(uint32_t)) rvp_acquire_release_t;
+
+typedef struct {
+	rvp_addr_t deltop;
+	uint32_t id;
+	uint32_t name_length;  // The name does not include the string
+	uint32_t name[];       // terminator.
+} __packed __aligned(sizeof(uint32_t)) rvp_shared_library_t;
+
+typedef struct {
+	rvp_addr_t deltop;
+	uint32_t library_id;
+	rvp_addr_t start_address;
+	uint32_t size;
+} __packed __aligned(sizeof(uint32_t)) rvp_shared_library_segment_t;
 
 #endif /* _RVP_TRACEFMT_H_ */

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -4,7 +4,7 @@
 # Mac OS X by installing a Pkgsrc bootstrap kit from pkgsrc.org.
 #
 
-PROGS=eitherorboth fork pass_array raise sigcount
+PROGS=eitherorboth fork load_library pass_array raise sigcount
 
 CC=clang
 CFLAGS+=-std=c11
@@ -19,6 +19,7 @@ SRCS.sigcount=sigcount.c
 SRCS.raise=raise.c
 SRCS.fork=fork.c
 SRCS.pass_array=pass_array.c
+SRCS.load_library=load_library.c
 WARNS=4
 
 .include <mkc.prog.mk>

--- a/misc/load_library.c
+++ b/misc/load_library.c
@@ -1,0 +1,178 @@
+#define _GNU_SOURCE
+#include <assert.h>
+#include <dlfcn.h>
+#include <limits.h>
+#include <link.h>
+#include <linux/limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+static int
+callback(struct dl_phdr_info *info, size_t size, void *data)
+{
+	char *type;
+	int p_type, j;
+
+	printf("Name: \"%s\" (%d segments)\n", info->dlpi_name,
+		info->dlpi_phnum);
+
+	for (j = 0; j < info->dlpi_phnum; j++) {
+		p_type = info->dlpi_phdr[j].p_type;
+		type =  (p_type == PT_LOAD) ? "PT_LOAD" :
+				(p_type == PT_DYNAMIC) ? "PT_DYNAMIC" :
+				(p_type == PT_INTERP) ? "PT_INTERP" :
+				(p_type == PT_NOTE) ? "PT_NOTE" :
+				(p_type == PT_INTERP) ? "PT_INTERP" :
+				(p_type == PT_PHDR) ? "PT_PHDR" :
+				(p_type == PT_TLS) ? "PT_TLS" :
+				(p_type == PT_GNU_EH_FRAME) ? "PT_GNU_EH_FRAME" :
+				(p_type == PT_GNU_STACK) ? "PT_GNU_STACK" :
+				(p_type == PT_GNU_RELRO) ? "PT_GNU_RELRO" : NULL;
+
+		printf("	%2d: [%14p; memsz:%7lx] flags: 0x%x; ", j,
+				(void *) (info->dlpi_addr + info->dlpi_phdr[j].p_vaddr),
+				info->dlpi_phdr[j].p_memsz,
+				info->dlpi_phdr[j].p_flags);
+		if (type != NULL)
+			printf("%s\n", type);
+		else
+			printf("[other (0x%x)]\n", p_type);
+		printf("	p_offset:%ld p_vaddr:%ld p_paddr:%ld p_filesz:%ld p_memsz:%ld p_align:%ld\n",
+				info->dlpi_phdr[j].p_offset,
+				info->dlpi_phdr[j].p_vaddr,
+				info->dlpi_phdr[j].p_paddr,
+				info->dlpi_phdr[j].p_filesz,
+				info->dlpi_phdr[j].p_memsz,
+				info->dlpi_phdr[j].p_align);
+	}
+
+	return 0;
+}
+
+void print_function(char* name, void* observed_address) {
+	void *handle;
+	char *error;
+
+	handle = dlopen("libc.so.6", RTLD_LAZY);
+	if (!handle) {
+		printf("%10s: %14p\n", name, observed_address);
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+
+	dlerror();	/* Clear any existing error */
+	printf("%10s: %14p / %14p\n", name, observed_address, dlsym(handle, name));
+	error = dlerror();
+	if (error != NULL) {
+		fprintf(stderr, "%s\n", error);
+		exit(EXIT_FAILURE);
+	}
+
+	dlclose(handle);
+}
+
+void print_link_map_entry(struct link_map* map) {
+	printf("  link_map: %14p\n", map);
+	printf("	l_addr: %lx\n", map->l_addr);
+	printf("	l_ld: %14p\n", map->l_ld);
+	printf("	  d_tag: %lx\n", map->l_ld->d_tag);
+	printf("	  d_val: %ld\n", map->l_ld->d_un.d_val);
+	printf("	  d_ptr: %14p\n", (void*)map->l_ld->d_un.d_ptr);
+}
+
+void print_library(char* name) {
+	printf("Loading library: %s\n", name);
+	void *handle;
+	handle = dlopen("libc.so.6", RTLD_LAZY);
+	if (!handle) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	printf("  Handle: %14p\n", handle);
+	
+	Lmid_t lmidt;
+	if (dlinfo(handle, RTLD_DI_LMID, &lmidt)) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	printf("  Namespace: 0x%016lx\n", lmidt);
+	
+	struct link_map* map;
+	if (dlinfo(handle, RTLD_DI_LINKMAP, &map)) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	struct link_map* current = map;
+	while (current != NULL) {
+		print_link_map_entry(current);
+		current = current->l_next;
+	}
+	current = map->l_prev;
+	while (current != NULL) {
+		print_link_map_entry(current);
+		current = current->l_prev;
+	}
+
+	char path[PATH_MAX + 1];
+	if (dlinfo(handle, RTLD_DI_ORIGIN, path)) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	printf("  Origin pathname: %s\n", path);
+
+	Dl_serinfo serinfo_for_size;
+	if (dlinfo(handle, RTLD_DI_SERINFOSIZE, &serinfo_for_size)) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	
+	Dl_serinfo *serinfo = malloc(serinfo_for_size.dls_size);
+	if (dlinfo(handle, RTLD_DI_SERINFOSIZE, serinfo)) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	assert(serinfo->dls_size == serinfo_for_size.dls_size);
+	if (dlinfo(handle, RTLD_DI_SERINFO, serinfo)) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	printf("  Serinfo size:\n");
+	printf("	size: %lu\n", serinfo_for_size.dls_size);
+	printf("	size: %lu\n", serinfo->dls_size);
+	printf("	count: %u\n", serinfo->dls_cnt);
+	assert(serinfo->dls_size == serinfo_for_size.dls_size);
+	for (int i = 0; i < serinfo->dls_cnt; i++) {
+		printf("	path[%d]\n", i);
+		printf("	  path: %s\n", serinfo->dls_serpath[i].dls_name);
+		printf("	  flags: %u\n", serinfo->dls_serpath[i].dls_flags);
+	}
+	free(serinfo);
+
+	size_t size;
+	if (dlinfo(handle, RTLD_DI_TLS_MODID, &size)) {
+		fprintf(stderr, "%s\n", dlerror());
+		exit(EXIT_FAILURE);
+	}
+	printf("  Module id: %lu\n", size);
+
+	dlclose(handle);
+}
+
+int main(int argc, char *argv[])
+{
+	dl_iterate_phdr(callback, NULL);
+
+	printf("main: %14p\n", main);
+	printf("callback: %14p\n", callback);
+	printf("printf: %14p\n", printf);
+	printf("fopen: %14p\n", fopen);
+	printf("stderr: %14p\n", &stderr);
+	printf("strlen: %14p\n", &strlen);
+	print_function("strlen", strlen);
+
+	print_library("libc.so.6");
+
+	
+	exit(EXIT_SUCCESS);
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/main/MaximalRaceDetector.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/main/MaximalRaceDetector.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.microsoft.z3.Context;
 import com.microsoft.z3.Params;
@@ -62,7 +63,7 @@ public class MaximalRaceDetector implements RaceDetector {
     }
 
     private boolean isThreadSafeLocation(Trace trace, long locId) {
-        String locationSig = trace.metadata().getLocationSig(locId);
+        String locationSig = trace.metadata().getLocationSig(locId, Optional.of(trace.getSharedLibraries()));
         if (locationSig.startsWith("java.util.concurrent")
             || locationSig.startsWith("java.util.stream")) {
             return true;

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/main/RVPredict.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/engine/main/RVPredict.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import com.runtimeverification.rvpredict.config.Configuration;
 import com.runtimeverification.rvpredict.log.ILoggingEngine;
@@ -103,7 +104,7 @@ public class RVPredict {
             } else {
                 reports.forEach(r -> config.logger().report(r, Logger.MSGTYPE.REAL));
             }
-            traceCache.getLockGraph().runDeadlockDetection();
+            traceCache.getLockGraph().runDeadlockDetection(traceCache.getSharedLibraries());
         } catch (IOException e) {
             System.err.println("Error: I/O error during prediction.");
             System.err.println(e.getMessage());

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/Event.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/Event.java
@@ -102,6 +102,30 @@ public class Event extends ReadonlyEvent {
         return 0;
     }
 
+    @Override
+    public long getSharedLibraryId() {
+        assert false;
+        return 0;
+    }
+
+    @Override
+    public String getSharedLibraryName() {
+        assert false;
+        return "";
+    }
+
+    @Override
+    public long getSharedLibrarySegmentStart() {
+        assert false;
+        return 0;
+    }
+
+    @Override
+    public long getSharedLibrarySegmentEnd() {
+        assert false;
+        return 0;
+    }
+
     public void setOriginalThreadId(long tid) {
         originalThreadId = tid;
     }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/EventType.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/EventType.java
@@ -5,6 +5,8 @@ import com.runtimeverification.rvpredict.log.printers.EstablishSignalPrinter;
 import com.runtimeverification.rvpredict.log.printers.InvokeMethodPrinter;
 import com.runtimeverification.rvpredict.log.printers.LockPrinter;
 import com.runtimeverification.rvpredict.log.printers.ReadWriteSignalMaskPrinter;
+import com.runtimeverification.rvpredict.log.printers.SharedLibraryPrinter;
+import com.runtimeverification.rvpredict.log.printers.SharedLibrarySegmentPrinter;
 import com.runtimeverification.rvpredict.log.printers.SignalHandlerPrinter;
 import com.runtimeverification.rvpredict.log.printers.SignalMaskPrinter;
 import com.runtimeverification.rvpredict.log.printers.SignalNumberPrinter;
@@ -111,7 +113,9 @@ public enum EventType {
     UNBLOCK_SIGNALS(new SignalMaskPrinter("unblocksignals", ReadonlyEventInterface::getPartialSignalMask)),
 
     ENTER_SIGNAL(new SignalHandlerPrinter("entersignal")),
-    EXIT_SIGNAL(new SignalNumberPrinter("exitsignal"));
+    EXIT_SIGNAL(new SignalNumberPrinter("exitsignal")),
+    SHARED_LIBRARY(new SharedLibraryPrinter()),
+    SHARED_LIBRARY_SEGMENT(new SharedLibrarySegmentPrinter());
 
     private final EventPrinter printer;
 

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEvent.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEvent.java
@@ -106,6 +106,11 @@ public abstract class ReadonlyEvent implements ReadonlyEventInterface {
     }
 
     @Override
+    public boolean isSharedLibraryEvent() {
+        return getType() == EventType.SHARED_LIBRARY || getType() == EventType.SHARED_LIBRARY_SEGMENT;
+    }
+
+    @Override
     public long getLockId() {
         assert isPreLock() || isLock() ||  isUnlock();
         return getSyncObject();

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEventInterface.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEventInterface.java
@@ -25,6 +25,10 @@ public interface ReadonlyEventInterface extends Comparable<ReadonlyEventInterfac
     OptionalLong getCallSiteAddress();
     long unsafeGetDataInternalIdentifier();
     long unsafeGetDataValue();
+    long getSharedLibraryId();
+    String getSharedLibraryName();
+    long getSharedLibrarySegmentStart();
+    long getSharedLibrarySegmentEnd();
 
     LockRepresentation getLockRepresentation();
     ReadonlyEventInterface copy();
@@ -88,5 +92,5 @@ public interface ReadonlyEventInterface extends Comparable<ReadonlyEventInterfac
     long getLockId();
     boolean isSimilarTo(ReadonlyEventInterface event);
     boolean isSignalMaskRead();
-
+    boolean isSharedLibraryEvent();
 }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEvent.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEvent.java
@@ -98,6 +98,25 @@ public abstract class CompactEvent extends ReadonlyEvent {
     }
 
     @Override
+    public long getSharedLibraryId() {
+        throw new UnsupportedOperationException("Unsupported operation for " + getType());
+    }
+
+    @Override
+    public String getSharedLibraryName() {
+        throw new UnsupportedOperationException("Unsupported operation for " + getType());
+    }
+
+    @Override
+    public long getSharedLibrarySegmentStart() {
+        throw new UnsupportedOperationException("Unsupported operation for " + getType());
+    }
+    @Override
+    public long getSharedLibrarySegmentEnd() {
+        throw new UnsupportedOperationException("Unsupported operation for " + getType());
+    }
+
+    @Override
     public LockRepresentation getLockRepresentation() {
         throw new UnsupportedOperationException("Unsupported operation for " + getType());
     }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEventFactory.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEventFactory.java
@@ -3,6 +3,7 @@ package com.runtimeverification.rvpredict.log.compact;
 import com.runtimeverification.rvpredict.log.EventType;
 import com.runtimeverification.rvpredict.log.LockRepresentation;
 import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.log.compact.datatypes.Address;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,6 +12,53 @@ import java.util.OptionalLong;
 
 public class CompactEventFactory {
     private static final List<ReadonlyEventInterface> NO_EVENTS = Collections.emptyList();
+
+    public List<ReadonlyEventInterface> sharedLibrary(Context context, long libraryId, String libraryName) {
+        return Collections.singletonList(
+                new CompactEvent(context, EventType.SHARED_LIBRARY) {
+                    @Override
+                    public long getSharedLibraryId() {
+                        return libraryId;
+                    }
+
+                    @Override
+                    public String getSharedLibraryName() {
+                        return libraryName;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return super.toString() + " " + libraryId + " " + libraryName;
+                    }
+                }
+        );
+    }
+
+    public List<ReadonlyEventInterface> sharedLibrarySegment(
+            Context context, long libraryId, long start, long size) {
+        return Collections.singletonList(
+                new CompactEvent(context, EventType.SHARED_LIBRARY_SEGMENT) {
+                    @Override
+                    public long getSharedLibraryId() {
+                        return libraryId;
+                    }
+
+                    @Override
+                    public long getSharedLibrarySegmentStart() {
+                        return start;
+                    }
+                    @Override
+                    public long getSharedLibrarySegmentEnd() {
+                        return start + size;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return super.toString() + " " + libraryId + ": " + start + " -> " + (start + size);
+                    }
+                }
+        );
+    }
 
     private enum LockReason {
         NORMAL,

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/MultipartReadableAggregateData.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/MultipartReadableAggregateData.java
@@ -1,0 +1,56 @@
+package com.runtimeverification.rvpredict.log.compact;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Base class for multipart data objects. These are used when the data structure
+ * is not fully known before reading it, e.g. when it has fields of variable size.
+ */
+public class MultipartReadableAggregateData {
+    private List<ReadableAggregateDataPart> parts;
+    private int currentPart = 0;
+
+    /**
+     * Must be called before starting to read the data object.
+     */
+    public void startReading(TraceHeader header) throws InvalidTraceDataException {
+        currentPart = 0;
+        parts.get(0).initialize(header);
+    }
+
+    /**
+     * Returns true if the data object is not fully read.
+     */
+    public boolean stillHasPartsToRead() {
+        return currentPart < parts.size();
+    }
+
+    /**
+     * @return The size of the next part to be read.
+     */
+    public int nextPartSize() {
+        return parts.get(currentPart).size();
+    }
+
+    /**
+     * Reads the next data part, preparing to read the next one (if any).
+     */
+    public void readNextPartAndAdvance(TraceHeader header, ByteBuffer buffer) throws InvalidTraceDataException {
+        parts.get(currentPart).read(buffer);
+        currentPart++;
+        if (currentPart < parts.size()) {
+            parts.get(currentPart).initialize(header);
+        }
+    }
+
+    /**
+     * Configures the event parts that will be loaded by the current object.
+     *
+     * Normally it should be called once, in the constructor.
+     */
+    protected void setData(ReadableAggregateDataPart... parts) {
+        this.parts = Arrays.asList(parts);
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/ReadableAggregateData.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/ReadableAggregateData.java
@@ -1,12 +1,17 @@
 package com.runtimeverification.rvpredict.log.compact;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 
 public class ReadableAggregateData implements ReadableData {
     private List<ReadableData> childData;
     private int size;
-    
+
+    public void setData(ReadableData... childData) {
+        setData(Arrays.asList(childData));
+    }
+
     public void setData(List<ReadableData> childData) {
         this.childData = childData;
         this.size = childData.stream().mapToInt(ReadableData::size).sum();

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/ReadableAggregateDataPart.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/ReadableAggregateDataPart.java
@@ -1,0 +1,66 @@
+package com.runtimeverification.rvpredict.log.compact;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * Reader for a chunk of data, part of a multipart data. These are used when the data structure is not fully
+ * known before reading it, e.g. when it has fields of variable size.
+ */
+public class ReadableAggregateDataPart<S extends ReadableData, T extends ReadableData> {
+    private final Optional<ReadableAggregateDataPart<T, ? extends ReadableData>> previousReader;
+    private final Initializer<S, T> initializer;
+    private Optional<S> data = Optional.empty();
+
+    /**
+     * @param previousReader The previous data part, if any.
+     * @param initializer Object that creates the current data.
+     */
+    public ReadableAggregateDataPart(
+            Optional<ReadableAggregateDataPart<T, ? extends ReadableData>> previousReader,
+            Initializer<S, T> initializer) {
+        this.previousReader = previousReader;
+        this.initializer = initializer;
+    }
+
+    /**
+     * Initializes the current data. Assumes that the previous data (if any) was already read.
+     */
+    public void initialize(TraceHeader header) throws InvalidTraceDataException {
+        Optional<T> previous = Optional.empty();
+        if (previousReader.isPresent()) {
+            previous = Optional.of(previousReader.get().getValue());
+        }
+        data = Optional.of(initializer.initialize(header, previous));
+    }
+
+    /**
+     * {@link #initialize(TraceHeader)} must be called before this.
+     */
+    public int size() {
+        assert data.isPresent();
+        return data.get().size();
+
+    }
+
+    /**
+     * {@link #initialize(TraceHeader)} must be called before this.
+     */
+    public void read(ByteBuffer buffer) throws InvalidTraceDataException {
+        assert data.isPresent();
+        data.get().read(buffer);
+    }
+
+    public S getValue() {
+        assert data.isPresent();
+        return data.get();
+    }
+
+    /**
+     * Creates data given the previous part data.
+     */
+    @FunctionalInterface
+    public interface Initializer<S extends ReadableData, T extends ReadableData> {
+        S initialize(TraceHeader header, Optional<T> previousReader) throws InvalidTraceDataException;
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/TraceHeader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/TraceHeader.java
@@ -19,7 +19,7 @@ public class TraceHeader {
         if (versionNumberBytes[0] != 0
                 || versionNumberBytes[1] != 0
                 || versionNumberBytes[2] != 0
-                || versionNumberBytes[3] != 3) {
+                || versionNumberBytes[3] != 4) {
             throw new InvalidTraceDataException("Unknown version: " + Arrays.toString(versionNumberBytes));
         }
 

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/datatypes/StringData.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/datatypes/StringData.java
@@ -1,0 +1,49 @@
+package com.runtimeverification.rvpredict.log.compact.datatypes;
+
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.ReadableData;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Given its length, reads an ASCII string encoded on a whole number of int32s.
+ */
+public class StringData implements ReadableData {
+    private final int nameLength;
+    private final VariableInt block;
+    private String data;
+
+    public StringData(TraceHeader header, int nameLength) throws InvalidTraceDataException {
+        this.nameLength = nameLength;
+        this.block = new VariableInt(header, 4);
+    }
+
+    @Override
+    public int size() {
+        return 4 * ((nameLength + 3) / 4);
+    }
+
+    @Override
+    public void read(ByteBuffer buffer) throws InvalidTraceDataException {
+        byte[] bytes = new byte[nameLength];
+        int sizeInInts = size()/4;
+        for (int i = 0; i < sizeInInts; i++) {
+            block.read(buffer);
+            long value = block.getAsLong();
+            for (int j = 0; j < 4; j++) {
+                int index = i * 4 + j;
+                if (index < bytes.length) {
+                    bytes[index] =(byte) (value & 0xff);
+                }
+                value = value >>> 8;
+            }
+        }
+        data = new String(bytes, StandardCharsets.US_ASCII);
+    }
+
+    public String getAsString() {
+        return data;
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/GetSetSignalMaskReader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/GetSetSignalMaskReader.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 public class GetSetSignalMaskReader {
     public static CompactEventReader.Reader createReader() {
         return new SimpleDataReader<>(
-                header -> new TraceElement(header),
+                TraceElement::new,
                 (context, compactEventFactory, element) -> compactEventFactory.getSetSignalMask(
                         context,
                         element.readMask.getAsLong(),

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/LockManipulationReader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/LockManipulationReader.java
@@ -4,7 +4,8 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.datatypes.Address;
 
 public class LockManipulationReader {
-    public static CompactEventReader.Reader createReader(CompactEventReader.LockManipulationType lockManipulationType) {
+    public static CompactEventReader.Reader createReader(
+            CompactEventReader.LockManipulationType lockManipulationType) {
         return new SimpleDataReader<>(
                 Address::new,
                 (context, compactEventFactory, address) ->

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/MultipartDataReader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/MultipartDataReader.java
@@ -1,0 +1,58 @@
+package com.runtimeverification.rvpredict.log.compact.readers;
+
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
+import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
+import com.runtimeverification.rvpredict.log.compact.Context;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.MultipartReadableAggregateData;
+import com.runtimeverification.rvpredict.log.compact.ReadableAggregateData;
+import com.runtimeverification.rvpredict.log.compact.ReadableData;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Reads multi-part data, building a list of events.
+ * @param <T> The exact type of multipart reader to be used.
+ */
+public class MultipartDataReader<T extends MultipartReadableAggregateData> implements
+        CompactEventReader.Reader {
+    private final T data;
+    private final SimpleDataReader.ReadableDataToEventListConverter<T> converter;
+
+    MultipartDataReader(
+            T data,
+            SimpleDataReader.ReadableDataToEventListConverter<T> converter) {
+        this.data = data;
+        this.converter = converter;
+    }
+
+    @Override
+    public void startReading(TraceHeader header) throws InvalidTraceDataException {
+        data.startReading(header);
+    }
+
+    @Override
+    public boolean stillHasPartsToRead() {
+        return data.stillHasPartsToRead();
+    }
+
+    @Override
+    public int nextPartSize(TraceHeader header) throws InvalidTraceDataException {
+        return data.nextPartSize();
+    }
+
+    @Override
+    public void addPart(ByteBuffer buffer, TraceHeader header) throws InvalidTraceDataException {
+        data.readNextPartAndAdvance(header, buffer);
+    }
+
+    @Override
+    public List<ReadonlyEventInterface> build(
+            Context context, CompactEventFactory compactEventFactory, TraceHeader header)
+            throws InvalidTraceDataException {
+        return converter.dataElementToEvent(context, compactEventFactory, data);
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/NoDataReader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/NoDataReader.java
@@ -1,7 +1,6 @@
 package com.runtimeverification.rvpredict.log.compact.readers;
 
 import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
-import com.runtimeverification.rvpredict.log.compact.CompactEvent;
 import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
 import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
@@ -29,13 +28,26 @@ public class NoDataReader implements CompactEventReader.Reader {
     }
 
     @Override
-    public int size(TraceHeader header) throws InvalidTraceDataException {
+    public void startReading(TraceHeader header) {
+    }
+
+    @Override
+    public boolean stillHasPartsToRead() {
+        return false;
+    }
+
+    @Override
+    public int nextPartSize(TraceHeader header) throws InvalidTraceDataException {
         return 0;
     }
 
     @Override
-    public List<ReadonlyEventInterface> readEvent(
-            Context context, CompactEventFactory compactEventFactory, TraceHeader header, ByteBuffer buffer)
+    public void addPart(ByteBuffer buffer, TraceHeader header) throws InvalidTraceDataException {
+    }
+
+    @Override
+    public List<ReadonlyEventInterface> build(
+            Context context, CompactEventFactory compactEventFactory, TraceHeader header)
             throws InvalidTraceDataException {
         return eventFactory.apply(compactEventFactory, context);
     }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibraryReader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibraryReader.java
@@ -1,0 +1,69 @@
+package com.runtimeverification.rvpredict.log.compact.readers;
+
+import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.MultipartReadableAggregateData;
+import com.runtimeverification.rvpredict.log.compact.ReadableAggregateData;
+import com.runtimeverification.rvpredict.log.compact.ReadableAggregateDataPart;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.log.compact.datatypes.StringData;
+import com.runtimeverification.rvpredict.log.compact.datatypes.VariableInt;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Reads a shared library event. A shared library event is composed of:
+ * 4-bytes library id
+ * 4-bytes library name length
+ * ASCII library name characters, padded to finish at a 4-bytes boundary.
+ */
+public class SharedLibraryReader extends MultipartDataReader<SharedLibraryReader.TraceElement> {
+    private SharedLibraryReader() {
+        super(new TraceElement(),
+                ((context, compactEventFactory, element) -> compactEventFactory.sharedLibrary(
+                        context,
+                        element.firstPart.getValue().id.getAsLong(),
+                        element.secondPart.getValue().name.getAsString())));
+    }
+
+    public static CompactEventReader.Reader createReader() {
+        return new SharedLibraryReader();
+    }
+
+    static class TraceElement extends MultipartReadableAggregateData {
+        private final ReadableAggregateDataPart<SharedLibraryReaderDataPart1, ReadableAggregateData> firstPart;
+        private final ReadableAggregateDataPart<SharedLibraryReaderDataPart2, SharedLibraryReaderDataPart1>
+                secondPart;
+
+        private TraceElement() {
+            this.firstPart = new ReadableAggregateDataPart<>(
+                    Optional.empty(), (header, previous) -> new SharedLibraryReaderDataPart1(header));
+            this.secondPart = new ReadableAggregateDataPart<>(
+                    Optional.of(this.firstPart),
+                    (header, previous) -> new SharedLibraryReaderDataPart2(header, previous.get()));
+            setData(firstPart, secondPart);
+        }
+    }
+
+    static class SharedLibraryReaderDataPart1 extends ReadableAggregateData {
+        private final VariableInt id;
+        private final VariableInt nameLength;
+
+        private SharedLibraryReaderDataPart1(TraceHeader header) throws InvalidTraceDataException {
+            id = new VariableInt(header, 4);
+            nameLength = new VariableInt(header, 4);
+            this.setData(Arrays.asList(id, nameLength));
+        }
+    }
+
+    static class SharedLibraryReaderDataPart2 extends ReadableAggregateData {
+        private final StringData name;
+        private SharedLibraryReaderDataPart2(TraceHeader header, SharedLibraryReaderDataPart1 previousData)
+                throws InvalidTraceDataException {
+            name = new StringData(header, Math.toIntExact(previousData.nameLength.getAsLong()));
+            this.setData(Collections.singletonList(name));
+        }
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibrarySegment.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibrarySegment.java
@@ -1,0 +1,40 @@
+package com.runtimeverification.rvpredict.log.compact.readers;
+
+import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.ReadableAggregateData;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.log.compact.datatypes.Address;
+import com.runtimeverification.rvpredict.log.compact.datatypes.VariableInt;
+
+/**
+ * Reads a shared library event segment. A shared library segment event is composed of:
+ * 4-bytes library id
+ * segment start pointer
+ * 4-bytes segment length
+ */
+public class SharedLibrarySegment {
+    public static CompactEventReader.Reader createReader() {
+        return new SimpleDataReader<>(
+                TraceElement::new,
+                (context, compactEventFactory, element) ->
+                        compactEventFactory.sharedLibrarySegment(
+                                context,
+                                element.libraryId.getAsLong(),
+                                element.start.getAsLong(),
+                                element.size.getAsLong()));
+    }
+
+    private static class TraceElement extends ReadableAggregateData {
+        private final VariableInt libraryId;
+        private final Address start;
+        private final VariableInt size;
+
+        private TraceElement(TraceHeader header) throws InvalidTraceDataException {
+            libraryId = new VariableInt(header, 4);
+            start = new Address(header);
+            size = new VariableInt(header, 4);
+            setData(libraryId, start, size);
+        }
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/SimpleDataReader.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/compact/readers/SimpleDataReader.java
@@ -10,10 +10,42 @@ import com.runtimeverification.rvpredict.log.compact.TraceHeader;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Optional;
 
 class SimpleDataReader<T extends ReadableData> implements CompactEventReader.Reader {
     private final LazyInitializer<T> reader;
     private final ReadableDataToEventListConverter<T> converter;
+    private Optional<T> data = Optional.empty();
+
+    @Override
+    public void startReading(TraceHeader header) throws InvalidTraceDataException {
+        data = Optional.empty();
+    }
+
+    @Override
+    public boolean stillHasPartsToRead() {
+        return !data.isPresent();
+    }
+
+    @Override
+    public int nextPartSize(TraceHeader header) throws InvalidTraceDataException {
+        return reader.getInit(header).size();
+    }
+
+    @Override
+    public void addPart(ByteBuffer buffer, TraceHeader header) throws InvalidTraceDataException {
+        T element = reader.getInit(header);
+        element.read(buffer);
+        data = Optional.of(element);
+    }
+
+    @Override
+    public List<ReadonlyEventInterface> build(
+        Context context, CompactEventFactory compactEventFactory, TraceHeader header)
+            throws InvalidTraceDataException {
+        assert data.isPresent();
+        return converter.dataElementToEvent(context, compactEventFactory, data.get());
+    }
 
     interface ReadableDataToEventListConverter<T> {
         List<ReadonlyEventInterface> dataElementToEvent(
@@ -25,19 +57,5 @@ class SimpleDataReader<T extends ReadableData> implements CompactEventReader.Rea
             LazyInitializer.Factory<T> readerFactory, ReadableDataToEventListConverter<T> converter) {
         this.reader = new LazyInitializer<>(readerFactory);
         this.converter = converter;
-    }
-
-    @Override
-    public int size(TraceHeader header) throws InvalidTraceDataException {
-        return reader.getInit(header).size();
-    }
-
-    @Override
-    public List<ReadonlyEventInterface> readEvent(
-            Context context, CompactEventFactory compactEventFactory, TraceHeader header, ByteBuffer buffer)
-            throws InvalidTraceDataException {
-        T element = reader.getInit(header);
-        element.read(buffer);
-        return converter.dataElementToEvent(context, compactEventFactory, element);
     }
 }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/printers/SharedLibraryPrinter.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/printers/SharedLibraryPrinter.java
@@ -1,0 +1,15 @@
+package com.runtimeverification.rvpredict.log.printers;
+
+import com.runtimeverification.rvpredict.log.EventPrinter;
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+
+public class SharedLibraryPrinter extends EventPrinter {
+    public SharedLibraryPrinter() {
+        super("shared-library");
+    }
+
+    @Override
+    protected String getEventContent(ReadonlyEventInterface event) {
+        return event.getSharedLibraryId() + " " + event.getSharedLibraryName();
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/printers/SharedLibrarySegmentPrinter.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/log/printers/SharedLibrarySegmentPrinter.java
@@ -1,0 +1,17 @@
+package com.runtimeverification.rvpredict.log.printers;
+
+import com.runtimeverification.rvpredict.log.EventPrinter;
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+
+public class SharedLibrarySegmentPrinter extends EventPrinter {
+    public SharedLibrarySegmentPrinter() {
+        super("shared-library-segment");
+    }
+
+    @Override
+    protected String getEventContent(ReadonlyEventInterface event) {
+        return event.getSharedLibraryId() + ": " + event.getSharedLibrarySegmentStart()
+                + " -> " + event.getSharedLibrarySegmentEnd();
+    }
+
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/CompactMetadata.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/CompactMetadata.java
@@ -3,6 +3,7 @@ package com.runtimeverification.rvpredict.metadata;
 import com.runtimeverification.rvpredict.config.Configuration;
 import com.runtimeverification.rvpredict.log.LockRepresentation;
 import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.trace.SharedLibraries;
 import com.runtimeverification.rvpredict.trace.Trace;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -19,8 +20,14 @@ public class CompactMetadata implements MetadataInterface {
     private final Map<Long, Pair<Long, Long>> otidToCreationInfo = new ConcurrentHashMap<>();
 
     @Override
-    public String getLocationSig(long locationId) {
-        return String.format("{0x%016x}", locationId);
+    public String getLocationSig(long locationId, Optional<SharedLibraries> sharedLibraries) {
+        Optional<String> defaultLibraryName = Optional.empty();
+        if (sharedLibraries.isPresent()) {
+            defaultLibraryName = sharedLibraries.get().getSharedLibraryNameFromAddress(locationId);
+        }
+        return defaultLibraryName
+                .map(name -> String.format("{0x%016x|%s}", locationId, name))
+                .orElse(String.format("{0x%016x}", locationId));
     }
 
     @Override

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/Metadata.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/Metadata.java
@@ -2,22 +2,20 @@ package com.runtimeverification.rvpredict.metadata;
 
 import com.runtimeverification.rvpredict.config.Configuration;
 import com.runtimeverification.rvpredict.log.LZ4Utils;
-import com.runtimeverification.rvpredict.log.LockRepresentation;
 import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.trace.SharedLibraries;
 import com.runtimeverification.rvpredict.trace.Trace;
 import org.apache.commons.lang3.tuple.Pair;
+import sun.security.provider.SHA;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -138,13 +136,17 @@ public class Metadata implements MetadataInterface, Serializable {
         return locId;
     }
 
-    @Override
     public String getLocationSig(long locId) {
         String sig = locIdToLocSig[Math.toIntExact(locId)];
         if (Configuration.debug && sig == null) {
             System.err.println("getLocationSig(" + locId + ") -> null");
         }
         return sig;
+    }
+
+    @Override
+    public String getLocationSig(long locId, Optional<SharedLibraries> sharedLibraries) {
+        return getLocationSig(locId);
     }
 
     @Override

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/MetadataInterface.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/metadata/MetadataInterface.java
@@ -1,12 +1,14 @@
 package com.runtimeverification.rvpredict.metadata;
 
 import com.runtimeverification.rvpredict.config.Configuration;
-import com.runtimeverification.rvpredict.log.LockRepresentation;
 import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.trace.SharedLibraries;
 import com.runtimeverification.rvpredict.trace.Trace;
 
+import java.util.Optional;
+
 public interface MetadataInterface {
-    String getLocationSig(long locationId);
+    String getLocationSig(long locationId, Optional<SharedLibraries> sharedLibraries);
     String getRaceDataSig(ReadonlyEventInterface e1, ReadonlyEventInterface e2, Trace trace, Configuration config);
     String getLocationPrefix();
     void addOriginalThreadCreationInfo(long childOTID, long parentOTID, long locId);

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/SharedLibraries.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/SharedLibraries.java
@@ -1,0 +1,34 @@
+package com.runtimeverification.rvpredict.trace;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Collection of shared libraries used in the trace.
+ */
+public class SharedLibraries {
+    private final List<SharedLibrary> sharedLibraries = new ArrayList<>();
+
+    public void addAll(Collection<SharedLibrary> libraries) {
+        sharedLibraries.addAll(libraries);
+    }
+
+    /**
+     * Given an addres, returns the name of the shared library that contains that address (if any).
+     */
+    public Optional<String> getSharedLibraryNameFromAddress(long address) {
+        Optional<String> name = Optional.empty();
+        // This could be optimized (e.g. one could do a binary search over the segments), but I (Virgil)
+        // am assuming that the number of library segments is relatively small and that this method is
+        // called rarely.
+        for (SharedLibrary library : sharedLibraries) {
+            if (library.containsAddress(address)) {
+                assert !name.isPresent();
+                name = Optional.of(library.getName());
+            }
+        }
+        return name;
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/SharedLibrary.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/SharedLibrary.java
@@ -1,0 +1,43 @@
+package com.runtimeverification.rvpredict.trace;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A shared library as described in a trace.
+ */
+public class SharedLibrary {
+    private final String name;
+    private final ImmutableList<Segment> segments;
+
+    public SharedLibrary(String name, ImmutableList<Segment> segments) {
+        this.name = name;
+        this.segments = segments;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean containsAddress(long address) {
+        for (Segment segment : segments) {
+            if (segment.containsAddress(address)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static class Segment {
+        private final long sharedLibrarySegmentStart;
+        private final long sharedLibrarySegmentEnd;
+
+        public Segment(long sharedLibrarySegmentStart, long sharedLibrarySegmentEnd) {
+            this.sharedLibrarySegmentStart = sharedLibrarySegmentStart;
+            this.sharedLibrarySegmentEnd = sharedLibrarySegmentEnd;
+        }
+
+        public boolean containsAddress(long address) {
+            return sharedLibrarySegmentStart <= address && address < sharedLibrarySegmentEnd;
+        }
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
@@ -467,6 +467,8 @@ public class Trace {
                                 .computeIfAbsent(event.getSignalHandlerAddress(), k -> new ArrayList<>())
                                 .add(event);
                     }
+                } else if (event.isSharedLibraryEvent()) {
+                    // Do nothing.
                 } else {
 		    if (state.config().isDebug())
 		        System.err.println(event.getType());
@@ -718,7 +720,8 @@ public class Trace {
      */
     public void printEvents() {
         tidToEvents.values().stream().flatMap(List::stream).sorted().forEach(event -> logger()
-                .debug((event + " at " + metadata().getLocationSig(event.getLocationId()))));
+                .debug((event + " at " + metadata().getLocationSig(event.getLocationId(),
+                        Optional.of(getSharedLibraries())))));
     }
 
     public OptionalInt getMainTraceThreadForOriginalThread(long originalThreadId) {
@@ -881,5 +884,9 @@ public class Trace {
 
     public List<ReadonlyEventInterface> getInterThreadSyncEvents() {
         return state.getTraceProducers().interThreadSyncEvents.getComputed().getSyncEvents();
+    }
+
+    public SharedLibraries getSharedLibraries() {
+        return state.getSharedLibraries();
     }
 }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/TraceCache.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/TraceCache.java
@@ -328,4 +328,8 @@ public class TraceCache {
         /* finish reading events and create the Trace object */
         return rawTraces.isEmpty() ? null : crntState.initNextTraceWindow(rawTraces);
     }
+
+    public SharedLibraries getSharedLibraries() {
+        return crntState.getSharedLibraries();
+    }
 }

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/producers/TraceProducers.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/producers/TraceProducers.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.producerframework.ProducerState;
 import com.runtimeverification.rvpredict.signals.SignalMask;
 import com.runtimeverification.rvpredict.trace.RawTrace;
 import com.runtimeverification.rvpredict.trace.ThreadInfos;
+import com.runtimeverification.rvpredict.trace.producers.base.SharedLibraries;
 import com.runtimeverification.rvpredict.trace.producers.base.InterThreadSyncEvents;
 import com.runtimeverification.rvpredict.trace.producers.base.MinEventIdForWindow;
 import com.runtimeverification.rvpredict.trace.producers.base.OtidToMainTtid;
@@ -56,6 +57,8 @@ public class TraceProducers extends ProducerModule {
     private final LeafProducerWrapper<Set<Integer>, TtidSetLeaf> ttidsFinishedAtWindowEnd =
             new LeafProducerWrapper<>(new TtidSetLeaf(), this);
 
+    public final ComputingProducerWrapper<SharedLibraries> sharedLibraries =
+            new ComputingProducerWrapper<>(new SharedLibraries(rawTraces), this);
     public final ComputingProducerWrapper<InterThreadSyncEvents> interThreadSyncEvents =
             new ComputingProducerWrapper<>(new InterThreadSyncEvents(rawTraces), this);
     public final ComputingProducerWrapper<TtidToStartAndJoinEventsForWindow> startAndJoinEventsForWindow =

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/producers/base/SharedLibraries.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/trace/producers/base/SharedLibraries.java
@@ -1,0 +1,69 @@
+package com.runtimeverification.rvpredict.trace.producers.base;
+
+import com.google.common.collect.ImmutableList;
+import com.runtimeverification.rvpredict.log.EventType;
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.producerframework.ComputingProducer;
+import com.runtimeverification.rvpredict.producerframework.ComputingProducerWrapper;
+import com.runtimeverification.rvpredict.producerframework.ProducerState;
+import com.runtimeverification.rvpredict.trace.SharedLibrary;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Computes the shared libraries found in the trace. Assumes that a library fully fits in a trace window.
+ */
+public class SharedLibraries extends ComputingProducer<SharedLibraries.State> {
+    private final RawTraces rawTraces;
+
+    public SharedLibraries(ComputingProducerWrapper<RawTraces> rawTraces) {
+        super(new State());
+        this.rawTraces = rawTraces.getAndRegister(this);
+    }
+
+    @Override
+    protected void compute() {
+        Map<Long, String> libraryNames = new HashMap<>();
+        Map<Long, ImmutableList.Builder<SharedLibrary.Segment>> librarySegments = new HashMap<>();
+        rawTraces.getTraces().forEach(rawTrace -> {
+            for (int i = 0; i < rawTrace.size(); i++) {
+                ReadonlyEventInterface event = rawTrace.event(i);
+                if (event.getType() == EventType.SHARED_LIBRARY) {
+                    libraryNames.put(event.getSharedLibraryId(), event.getSharedLibraryName());
+                } else if (event.getType() == EventType.SHARED_LIBRARY_SEGMENT) {
+                    librarySegments
+                            .computeIfAbsent(event.getSharedLibraryId(), k -> new ImmutableList.Builder<>())
+                            .add(new SharedLibrary.Segment(
+                                    event.getSharedLibrarySegmentStart(), event.getSharedLibrarySegmentEnd()));
+                }
+            }
+        });
+        libraryNames.forEach((id, name) ->
+                getState().sharedLibraries.add(new SharedLibrary(
+                        name,
+                        librarySegments
+                                .getOrDefault(id, new ImmutableList.Builder<>())
+                                .build())));
+        for (Long id : librarySegments.keySet()) {
+            if (!libraryNames.containsKey(id)) {
+                throw new IllegalStateException("Library segment without library name for id: " + id + ".");
+            }
+        }
+    }
+
+    public Collection<SharedLibrary> getLibraries() {
+        return getState().sharedLibraries;
+    }
+
+    public static class State implements ProducerState {
+        List<SharedLibrary> sharedLibraries = new ArrayList<>();
+        @Override
+        public void reset() {
+            sharedLibraries.clear();
+        }
+    }
+}

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/util/ReadLogFile.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/util/ReadLogFile.java
@@ -9,6 +9,7 @@ import com.runtimeverification.rvpredict.metadata.MetadataInterface;
 import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 /**
  * Debugging class for printing the contents of a log file to console.
@@ -42,7 +43,7 @@ public class ReadLogFile {
             }
             System.out.println("#program location section#");
             for (int locId = 1;; locId++) {
-                String locSig = metadata.getLocationSig(locId);
+                String locSig = metadata.getLocationSig(locId, Optional.empty());
                 if (locSig != null) {
                     System.out.printf("%s:%s%n", locId, locSig);
                 } else {
@@ -54,7 +55,8 @@ public class ReadLogFile {
                 System.out.println("Dumping events from " + file);
                 while (true) {
                     ReadonlyEventInterface event = reader.readEvent();
-                    String locSig = event.getLocationId() < 0 ? "n/a" : metadata.getLocationSig(event.getLocationId());
+                    String locSig = event.getLocationId() < 0 ?
+                            "n/a" : metadata.getLocationSig(event.getLocationId(), Optional.empty());
                     System.out.printf("%-60s %s%n", event.toString(), locSig);
                 }
             } catch (EOFException ignored) {

--- a/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/util/ReadTrace.java
+++ b/rv-predict-source/src/main/java/com/runtimeverification/rvpredict/util/ReadTrace.java
@@ -8,6 +8,7 @@ import com.runtimeverification.rvpredict.order.VectorClockTraceReader;
 import com.runtimeverification.rvpredict.trace.OrderedLoggedTraceReader;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public class ReadTrace {
     public static void main(String args[]) {
@@ -19,7 +20,7 @@ public class ReadTrace {
                     ReadonlyOrderedEvent event = reader.readEvent();
                     String locSig = event.getEvent().getLocationId() < 0 ?
                             "n/a" :
-                            metadata.getLocationSig(event.getEvent().getLocationId());
+                            metadata.getLocationSig(event.getEvent().getLocationId(), Optional.empty());
                     System.out.printf("%s %s%n", event.toString(), locSig);
                 }
         }

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/MultipartReadableAggregateDataTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/MultipartReadableAggregateDataTest.java
@@ -1,0 +1,87 @@
+package com.runtimeverification.rvpredict.log.compact;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MultipartReadableAggregateDataTest {
+    @Mock private ReadableAggregateDataPart mockPart1;
+    @Mock private ReadableAggregateDataPart mockPart2;
+    @Mock private ReadableAggregateData mockData1;
+    @Mock private ReadableAggregateData mockData2;
+    @Mock private TraceHeader mockTraceHeader;
+    @Mock private ByteBuffer mockBuffer;
+
+    @Test
+    public void zeroPartsData() {
+        MultipartReadableAggregateData data = new MultipartReadableAggregateDataForTest();
+        Assert.assertFalse(data.stillHasPartsToRead());
+    }
+
+    @Test
+    public void onePartData() throws InvalidTraceDataException {
+        MultipartReadableAggregateData data = new MultipartReadableAggregateDataForTest(mockPart1);
+
+        verify(mockPart1, never()).initialize(mockTraceHeader);
+        data.startReading(mockTraceHeader);
+        verify(mockPart1).initialize(mockTraceHeader);
+
+        Assert.assertTrue(data.stillHasPartsToRead());
+
+        when(mockPart1.size()).thenReturn(10);
+        Assert.assertEquals(10, data.nextPartSize());
+
+        verify(mockPart1, never()).read(mockBuffer);
+        data.readNextPartAndAdvance(mockTraceHeader, mockBuffer);
+        verify(mockPart1).read(mockBuffer);
+
+        Assert.assertFalse(data.stillHasPartsToRead());
+    }
+
+    @Test
+    public void multipartData() throws InvalidTraceDataException {
+        MultipartReadableAggregateData data = new MultipartReadableAggregateDataForTest(mockPart1, mockPart2);
+
+        verify(mockPart1, never()).initialize(mockTraceHeader);
+        data.startReading(mockTraceHeader);
+        verify(mockPart1).initialize(mockTraceHeader);
+
+        Assert.assertTrue(data.stillHasPartsToRead());
+
+        when(mockPart1.size()).thenReturn(10);
+        Assert.assertEquals(10, data.nextPartSize());
+
+        verify(mockPart1, never()).read(mockBuffer);
+        verify(mockPart2, never()).initialize(mockTraceHeader);
+        data.readNextPartAndAdvance(mockTraceHeader, mockBuffer);
+        verify(mockPart1).read(mockBuffer);
+        verify(mockPart2).initialize(mockTraceHeader);
+
+        Assert.assertTrue(data.stillHasPartsToRead());
+
+        when(mockPart2.size()).thenReturn(15);
+        Assert.assertEquals(15, data.nextPartSize());
+
+        verify(mockPart2, never()).read(mockBuffer);
+        data.readNextPartAndAdvance(mockTraceHeader, mockBuffer);
+        verify(mockPart2).read(mockBuffer);
+
+        Assert.assertFalse(data.stillHasPartsToRead());
+    }
+
+    private static class MultipartReadableAggregateDataForTest extends MultipartReadableAggregateData {
+        MultipartReadableAggregateDataForTest(ReadableAggregateDataPart... initializers) {
+            setData(initializers);
+        }
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/ReadableAggregateDataPartTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/ReadableAggregateDataPartTest.java
@@ -1,0 +1,64 @@
+package com.runtimeverification.rvpredict.log.compact;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReadableAggregateDataPartTest {
+    @Mock private ReadableAggregateData mockData1;
+    @Mock private ReadableAggregateData mockData2;
+    @Mock private ReadableAggregateDataPart.Initializer<ReadableAggregateData, ReadableAggregateData> mockInitializer;
+    @Mock private ReadableAggregateDataPart<ReadableAggregateData, ReadableAggregateDataForTest> mockDataPart;
+    @Mock private TraceHeader mockTraceHeader;
+    @Mock private ByteBuffer mockBuffer;
+
+    @Test
+    public void firstDataPart() throws InvalidTraceDataException {
+        ReadableAggregateDataPart<ReadableAggregateData, ReadableAggregateData> part =
+                new ReadableAggregateDataPart<>(Optional.empty(), mockInitializer);
+
+        when(mockInitializer.initialize(mockTraceHeader, Optional.empty())).thenReturn(mockData1);
+        verify(mockInitializer, never()).initialize(any(), any());
+        part.initialize(mockTraceHeader);
+        verify(mockInitializer).initialize(mockTraceHeader, Optional.empty());
+
+        Assert.assertEquals(mockData1, part.getValue());
+
+        verify(mockData1, never()).read(mockBuffer);
+        part.read(mockBuffer);
+        verify(mockData1).read(mockBuffer);
+    }
+
+    @Test
+    public void secondDataPart() throws InvalidTraceDataException {
+        when(mockInitializer.initialize(mockTraceHeader, Optional.of(mockData1))).thenReturn(mockData2);
+        when(mockDataPart.getValue()).thenReturn(mockData1);
+
+        ReadableAggregateDataPart<ReadableAggregateData, ReadableAggregateData> part =
+                new ReadableAggregateDataPart<>(Optional.of(mockDataPart), mockInitializer);
+
+        verify(mockInitializer, never()).initialize(any(), any());
+        part.initialize(mockTraceHeader);
+        verify(mockInitializer).initialize(mockTraceHeader, Optional.of(mockData1));
+
+        Assert.assertEquals(mockData2, part.getValue());
+
+        verify(mockData2, never()).read(mockBuffer);
+        part.read(mockBuffer);
+        verify(mockData2).read(mockBuffer);
+
+    }
+
+    private class ReadableAggregateDataForTest extends ReadableAggregateData {}
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/datatypes/StringDataTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/datatypes/StringDataTest.java
@@ -1,0 +1,73 @@
+package com.runtimeverification.rvpredict.log.compact.datatypes;
+
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StringDataTest {
+    @Mock private TraceHeader mockHeader;
+
+    @Test
+    public void returnsCorrectSizeWithDataWidth4() throws InvalidTraceDataException {
+        when(mockHeader.getPointerWidthInBytes()).thenReturn(4);
+        when(mockHeader.getDefaultDataWidthInBytes()).thenReturn(4);
+
+        Assert.assertEquals(0, new StringData(mockHeader, 0).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 1).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 2).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 3).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 4).size());
+        Assert.assertEquals(8, new StringData(mockHeader, 5).size());
+    }
+
+    @Test
+    public void returnsCorrectSizeWithDataWidth8() throws InvalidTraceDataException {
+        when(mockHeader.getPointerWidthInBytes()).thenReturn(8);
+        when(mockHeader.getDefaultDataWidthInBytes()).thenReturn(8);
+
+        Assert.assertEquals(0, new StringData(mockHeader, 0).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 1).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 2).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 3).size());
+        Assert.assertEquals(4, new StringData(mockHeader, 4).size());
+        Assert.assertEquals(8, new StringData(mockHeader, 5).size());
+    }
+
+    @Test
+    public void readsStrings() throws InvalidTraceDataException {
+        when(mockHeader.getPointerWidthInBytes()).thenReturn(4);
+        when(mockHeader.getDefaultDataWidthInBytes()).thenReturn(4);
+
+        ByteBuffer buffer = ByteBuffer.allocate(12)
+                .put((byte)'l').put((byte)'l').put((byte)'e').put((byte)'h')
+                .put((byte)0).put((byte)0).put((byte)0).put((byte)'o')
+                .putInt(Integer.MAX_VALUE);
+
+        buffer.rewind();
+        Assert.assertEquals("", readString(buffer, 0).getAsString());
+        Assert.assertEquals("h", readString(buffer, 1).getAsString());
+        buffer.rewind();
+        Assert.assertEquals("he", readString(buffer, 2).getAsString());
+        buffer.rewind();
+        Assert.assertEquals("hel", readString(buffer, 3).getAsString());
+        buffer.rewind();
+        Assert.assertEquals("hell", readString(buffer, 4).getAsString());
+        buffer.rewind();
+        Assert.assertEquals("hello", readString(buffer, 5).getAsString());
+    }
+
+    private StringData readString(ByteBuffer buffer, int size) throws InvalidTraceDataException {
+        StringData string = new StringData(mockHeader, size);
+        string.read(buffer);
+        return string;
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/AtomicReadModifyWriteReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/AtomicReadModifyWriteReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,8 +36,9 @@ public class AtomicReadModifyWriteReaderTest {
         when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
-        CompactEventReader.Reader reader = AtomicReadModifyWriteReader.createReader(2);
-        Assert.assertEquals(12, reader.size(mockTraceHeader));
+        CompactEventReader.Reader reader =
+                AtomicReadModifyWriteReader.createReader(2);
+        Assert.assertEquals(12, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -44,8 +46,9 @@ public class AtomicReadModifyWriteReaderTest {
         when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(1);
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
-        CompactEventReader.Reader reader = AtomicReadModifyWriteReader.createReader(2);
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        CompactEventReader.Reader reader =
+                AtomicReadModifyWriteReader.createReader(2);
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -53,8 +56,9 @@ public class AtomicReadModifyWriteReaderTest {
         when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
-        CompactEventReader.Reader reader = AtomicReadModifyWriteReader.createReader(2);
-        Assert.assertEquals(16, reader.size(mockTraceHeader));
+        CompactEventReader.Reader reader =
+                AtomicReadModifyWriteReader.createReader(2);
+        Assert.assertEquals(16, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -69,9 +73,10 @@ public class AtomicReadModifyWriteReaderTest {
                 .putLong(Long.MAX_VALUE);
         buffer.rewind();
 
-        CompactEventReader.Reader reader = AtomicReadModifyWriteReader.createReader(2);
+        CompactEventReader.Reader reader =
+                AtomicReadModifyWriteReader.createReader(2);
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/BlockSignalsReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/BlockSignalsReaderTest.java
@@ -6,6 +6,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +34,7 @@ public class BlockSignalsReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = BlockSignalsReader.createReader();
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
 
@@ -43,7 +44,7 @@ public class BlockSignalsReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = BlockSignalsReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -59,7 +60,7 @@ public class BlockSignalsReaderTest {
 
         CompactEventReader.Reader reader = BlockSignalsReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertTrue(EVENT_LIST == events);
     }

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/ChangeOfGenerationReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/ChangeOfGenerationReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +34,7 @@ public class ChangeOfGenerationReaderTest {
         when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = ChangeOfGenerationReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -47,7 +48,7 @@ public class ChangeOfGenerationReaderTest {
 
         CompactEventReader.Reader reader = ChangeOfGenerationReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/DataManipulationReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/DataManipulationReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ public class DataManipulationReaderTest {
 
         CompactEventReader.Reader reader = DataManipulationReader.createReader(
                 2, CompactEventReader.DataManipulationType.LOAD, CompactEventReader.Atomicity.NOT_ATOMIC);
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -46,7 +47,7 @@ public class DataManipulationReaderTest {
 
         CompactEventReader.Reader reader = DataManipulationReader.createReader(
                 2, CompactEventReader.DataManipulationType.LOAD, CompactEventReader.Atomicity.NOT_ATOMIC);
-        Assert.assertEquals(6, reader.size(mockTraceHeader));
+        Assert.assertEquals(6, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -56,7 +57,7 @@ public class DataManipulationReaderTest {
 
         CompactEventReader.Reader reader = DataManipulationReader.createReader(
                 2, CompactEventReader.DataManipulationType.LOAD, CompactEventReader.Atomicity.NOT_ATOMIC);
-        Assert.assertEquals(12, reader.size(mockTraceHeader));
+        Assert.assertEquals(12, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -75,7 +76,7 @@ public class DataManipulationReaderTest {
         CompactEventReader.Reader reader = DataManipulationReader.createReader(
                 2, CompactEventReader.DataManipulationType.LOAD, CompactEventReader.Atomicity.NOT_ATOMIC);
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/FunctionEnterReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/FunctionEnterReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ public class FunctionEnterReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
         CompactEventReader.Reader reader = FunctionEnterReader.createReader();
-        Assert.assertEquals(16, reader.size(mockTraceHeader));
+        Assert.assertEquals(16, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -53,7 +54,7 @@ public class FunctionEnterReaderTest {
 
         CompactEventReader.Reader reader = FunctionEnterReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/GetSetSignalMaskReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/GetSetSignalMaskReaderTest.java
@@ -6,6 +6,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ public class GetSetSignalMaskReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = GetSetSignalMaskReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, reader.nextPartSize(mockTraceHeader));
     }
 
 
@@ -44,7 +45,7 @@ public class GetSetSignalMaskReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = GetSetSignalMaskReader.createReader();
-        Assert.assertEquals(16, reader.size(mockTraceHeader));
+        Assert.assertEquals(16, reader.nextPartSize(mockTraceHeader));
     }
 
     @Test
@@ -60,7 +61,7 @@ public class GetSetSignalMaskReaderTest {
 
         CompactEventReader.Reader reader = GetSetSignalMaskReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertTrue(EVENT_LIST == events);
     }

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/GetSignalMaskReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/GetSignalMaskReaderTest.java
@@ -6,6 +6,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +34,7 @@ public class GetSignalMaskReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = GetSignalMaskReader.createReader();
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
 
@@ -43,7 +44,7 @@ public class GetSignalMaskReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = GetSignalMaskReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -59,7 +60,7 @@ public class GetSignalMaskReaderTest {
 
         CompactEventReader.Reader reader = GetSignalMaskReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertTrue(EVENT_LIST == events);
     }

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/LockManipulationReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/LockManipulationReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,7 +36,7 @@ public class LockManipulationReaderTest {
 
         CompactEventReader.Reader reader =
                 LockManipulationReader.createReader(CompactEventReader.LockManipulationType.LOCK);
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -45,7 +46,7 @@ public class LockManipulationReaderTest {
 
         CompactEventReader.Reader reader =
                 LockManipulationReader.createReader(CompactEventReader.LockManipulationType.LOCK);
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -62,7 +63,7 @@ public class LockManipulationReaderTest {
         CompactEventReader.Reader reader =
                 LockManipulationReader.createReader(CompactEventReader.LockManipulationType.LOCK);
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/MultipartDataReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/MultipartDataReaderTest.java
@@ -1,0 +1,77 @@
+package com.runtimeverification.rvpredict.log.compact.readers;
+
+import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
+import com.runtimeverification.rvpredict.log.compact.Context;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.MultipartReadableAggregateData;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MultipartDataReaderTest {
+    @Mock private MultipartReadableAggregateDataForTest mockMultipartReadableAggregateData;
+    @Mock private SimpleDataReader.ReadableDataToEventListConverter<MultipartReadableAggregateDataForTest>
+            mockConverter;
+    @Mock private TraceHeader mockHeader;
+    @Mock private ByteBuffer mockBuffer;
+    @Mock private CompactEventFactory mockCompactEventFactory;
+    @Mock private Context mockContext;
+
+    @Test
+    public void zeroPartsData() {
+        MultipartDataReader<MultipartReadableAggregateDataForTest> reader =
+                new MultipartDataReader<>(
+                        mockMultipartReadableAggregateData, mockConverter);
+        when(mockMultipartReadableAggregateData.stillHasPartsToRead())
+                .thenReturn(false);
+        Assert.assertFalse(reader.stillHasPartsToRead());
+    }
+
+    @Test
+    public void onePartData() throws InvalidTraceDataException {
+        MultipartDataReader<MultipartReadableAggregateDataForTest> reader =
+                new MultipartDataReader<>(
+                        mockMultipartReadableAggregateData, mockConverter);
+
+        verify(mockMultipartReadableAggregateData, never()).startReading(mockHeader);
+        verify(mockMultipartReadableAggregateData, never()).readNextPartAndAdvance(any(), any());
+
+        reader.startReading(mockHeader);
+
+        verify(mockMultipartReadableAggregateData).startReading(mockHeader);
+        verify(mockMultipartReadableAggregateData, never()).readNextPartAndAdvance(any(), any());
+
+        when(mockMultipartReadableAggregateData.stillHasPartsToRead()).thenReturn(true);
+        Assert.assertTrue(reader.stillHasPartsToRead());
+
+        when(mockMultipartReadableAggregateData.nextPartSize()).thenReturn(10);
+        Assert.assertEquals(10, reader.nextPartSize(mockHeader));
+
+        verify(mockMultipartReadableAggregateData).startReading(mockHeader);
+        verify(mockMultipartReadableAggregateData, never()).readNextPartAndAdvance(any(), any());
+
+        reader.addPart(mockBuffer, mockHeader);
+
+        verify(mockMultipartReadableAggregateData).startReading(mockHeader);
+        verify(mockMultipartReadableAggregateData).readNextPartAndAdvance(mockHeader, mockBuffer);
+
+        verify(mockConverter, never())
+                .dataElementToEvent(mockContext, mockCompactEventFactory, mockMultipartReadableAggregateData);
+        reader.build(mockContext, mockCompactEventFactory, mockHeader);
+        verify(mockConverter)
+                .dataElementToEvent(mockContext, mockCompactEventFactory, mockMultipartReadableAggregateData);
+    }
+
+    private static class MultipartReadableAggregateDataForTest extends MultipartReadableAggregateData {}
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/NoDataReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/NoDataReaderTest.java
@@ -6,6 +6,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +32,7 @@ public class NoDataReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
         NoDataReader reader = new NoDataReader((factory, context) -> Collections.singletonList(mockCompactEvent));
-        Assert.assertEquals(0, reader.size(mockTraceHeader));
+        Assert.assertEquals(0, reader.nextPartSize(mockTraceHeader));
     }
 
     @Test
@@ -39,7 +40,7 @@ public class NoDataReaderTest {
         ByteBuffer buffer = ByteBuffer.allocate(0);
         NoDataReader reader = new NoDataReader((factory, context) -> Collections.singletonList(mockCompactEvent));
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibraryReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibraryReaderTest.java
@@ -1,0 +1,62 @@
+package com.runtimeverification.rvpredict.log.compact.readers;
+
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
+import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
+import com.runtimeverification.rvpredict.log.compact.Context;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SharedLibraryReaderTest {
+    private static final int LIBRARY_ID = 101;
+    private static final List<ReadonlyEventInterface> EVENT_LIST = new ArrayList<>();
+
+    @Mock private Context mockContext;
+    @Mock private TraceHeader mockTraceHeader;
+    @Mock private CompactEventFactory mockCompactEventFactory;
+
+    @Test
+    public void readsData() throws InvalidTraceDataException {
+        when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
+        when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
+        when(mockCompactEventFactory.sharedLibrary(mockContext, LIBRARY_ID, "hello"))
+                .thenReturn(EVENT_LIST);
+
+        ByteBuffer buffer1 = ByteBuffer.allocate(24)
+                .putInt(LIBRARY_ID).putInt(5)
+                .putLong(Long.MAX_VALUE);
+        buffer1.rewind();
+        ByteBuffer buffer2 = ByteBuffer.allocate(24)
+                .put((byte)'l').put((byte)'l').put((byte)'e').put((byte)'h')
+                .put((byte)0).put((byte)0).put((byte)0).put((byte)'o')
+                .putLong(Long.MAX_VALUE);
+        buffer2.rewind();
+
+        CompactEventReader.Reader reader = SharedLibraryReader.createReader();
+
+        reader.startReading(mockTraceHeader);
+
+        Assert.assertTrue(reader.stillHasPartsToRead());
+        Assert.assertEquals(8, reader.nextPartSize(mockTraceHeader));
+        reader.addPart(buffer1, mockTraceHeader);
+
+        Assert.assertTrue(reader.stillHasPartsToRead());
+        Assert.assertEquals(8, reader.nextPartSize(mockTraceHeader));
+        reader.addPart(buffer2, mockTraceHeader);
+
+        Assert.assertFalse(reader.stillHasPartsToRead());
+        Assert.assertEquals(EVENT_LIST, reader.build(mockContext, mockCompactEventFactory, mockTraceHeader));
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibrarySegmentTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SharedLibrarySegmentTest.java
@@ -1,0 +1,71 @@
+package com.runtimeverification.rvpredict.log.compact.readers;
+
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.log.compact.CompactEvent;
+import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
+import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
+import com.runtimeverification.rvpredict.log.compact.Context;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SharedLibrarySegmentTest {
+    private static final int LIBRARY_ID = 101;
+    private static final long START = 201;
+    private static final int SIZE = 301;
+
+    @Mock private CompactEvent mockCompactEvent;
+    @Mock private Context mockContext;
+    @Mock private TraceHeader mockTraceHeader;
+    @Mock private CompactEventFactory mockCompactEventFactory;
+
+    @Test
+    public void computesTheCorrectSizeDataSize_UsesPointerSize4Bytes() throws InvalidTraceDataException {
+        when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
+        when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
+
+        CompactEventReader.Reader reader = SharedLibrarySegment.createReader();
+        Assert.assertEquals(12, ReaderUtils.firstPartSize(reader, mockTraceHeader));
+    }
+
+    @Test
+    public void computesTheCorrectSizeDataSize_UsesPointerSize8Bytes() throws InvalidTraceDataException {
+        when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
+        when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
+
+        CompactEventReader.Reader reader = SharedLibrarySegment.createReader();
+        Assert.assertEquals(16, ReaderUtils.firstPartSize(reader, mockTraceHeader));
+    }
+
+    @Test
+    public void readsData() throws InvalidTraceDataException {
+        when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
+        when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
+        when(mockCompactEventFactory.sharedLibrarySegment(mockContext, LIBRARY_ID, START, SIZE))
+                .thenReturn(Collections.singletonList(mockCompactEvent));
+
+        ByteBuffer buffer = ByteBuffer.allocate(24)
+                .putInt(LIBRARY_ID).putLong(START).putInt(SIZE)
+                .putLong(Long.MAX_VALUE);
+        buffer.rewind();
+
+        CompactEventReader.Reader reader = SharedLibrarySegment.createReader();
+        List<ReadonlyEventInterface> events =
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+
+        Assert.assertEquals(1, events.size());
+        Assert.assertEquals(mockCompactEvent, events.get(0));
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalDisestablishReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalDisestablishReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ public class SignalDisestablishReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
         CompactEventReader.Reader reader = SignalDisestablishReader.createReader();
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -43,7 +44,7 @@ public class SignalDisestablishReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalDisestablishReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -58,7 +59,7 @@ public class SignalDisestablishReaderTest {
 
         CompactEventReader.Reader reader = SignalDisestablishReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalEnterReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalEnterReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ public class SignalEnterReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
         CompactEventReader.Reader reader = SignalEnterReader.createReader();
-        Assert.assertEquals(20, reader.size(mockTraceHeader));
+        Assert.assertEquals(20, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -45,7 +46,7 @@ public class SignalEnterReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
         CompactEventReader.Reader reader = SignalEnterReader.createReader();
-        Assert.assertEquals(24, reader.size(mockTraceHeader));
+        Assert.assertEquals(24, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -61,7 +62,7 @@ public class SignalEnterReaderTest {
 
         CompactEventReader.Reader reader = SignalEnterReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalEstablishReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalEstablishReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ public class SignalEstablishReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalEstablishReader.createReader();
-        Assert.assertEquals(12, reader.size(mockTraceHeader));
+        Assert.assertEquals(12, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -45,7 +46,7 @@ public class SignalEstablishReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
         CompactEventReader.Reader reader = SignalEstablishReader.createReader();
-        Assert.assertEquals(24, reader.size(mockTraceHeader));
+        Assert.assertEquals(24, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -54,7 +55,7 @@ public class SignalEstablishReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(8);
 
         CompactEventReader.Reader reader = SignalEstablishReader.createReader();
-        Assert.assertEquals(16, reader.size(mockTraceHeader));
+        Assert.assertEquals(16, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -70,7 +71,7 @@ public class SignalEstablishReaderTest {
 
         CompactEventReader.Reader reader = SignalEstablishReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalMaskMemoizationReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalMaskMemoizationReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ public class SignalMaskMemoizationReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalMaskMemoizationReader.createReader();
-        Assert.assertEquals(16, reader.size(mockTraceHeader));
+        Assert.assertEquals(16, reader.nextPartSize(mockTraceHeader));
     }
 
     @Test
@@ -45,7 +46,7 @@ public class SignalMaskMemoizationReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalMaskMemoizationReader.createReader();
-        Assert.assertEquals(24, reader.size(mockTraceHeader));
+        Assert.assertEquals(24, reader.nextPartSize(mockTraceHeader));
     }
 
     @Test
@@ -61,7 +62,7 @@ public class SignalMaskMemoizationReaderTest {
 
         CompactEventReader.Reader reader = SignalMaskMemoizationReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalMaskReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalMaskReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ public class SignalMaskReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalMaskReader.createReader();
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -43,7 +44,7 @@ public class SignalMaskReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalMaskReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -59,7 +60,7 @@ public class SignalMaskReaderTest {
 
         CompactEventReader.Reader reader = SignalMaskReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalOutstandingDepthReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/SignalOutstandingDepthReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ public class SignalOutstandingDepthReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalDepthReader.createReader();
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -43,7 +44,7 @@ public class SignalOutstandingDepthReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = SignalDepthReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -59,7 +60,7 @@ public class SignalOutstandingDepthReaderTest {
 
         CompactEventReader.Reader reader = SignalDepthReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/ThreadBeginReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/ThreadBeginReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,7 +36,7 @@ public class ThreadBeginReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = ThreadBeginReader.createReader();
-        Assert.assertEquals(12, reader.size(mockTraceHeader));
+        Assert.assertEquals(12, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -44,7 +45,7 @@ public class ThreadBeginReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = ThreadBeginReader.createReader();
-        Assert.assertEquals(16, reader.size(mockTraceHeader));
+        Assert.assertEquals(16, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -60,7 +61,7 @@ public class ThreadBeginReaderTest {
 
         CompactEventReader.Reader reader = ThreadBeginReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/ThreadSyncReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/ThreadSyncReaderTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,8 +34,9 @@ public class ThreadSyncReaderTest {
         when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(4);
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
-        CompactEventReader.Reader reader = ThreadSyncReader.createReader(CompactEventReader.ThreadSyncType.SWITCH);
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        CompactEventReader.Reader reader =
+                ThreadSyncReader.createReader(CompactEventReader.ThreadSyncType.SWITCH);
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -42,8 +44,9 @@ public class ThreadSyncReaderTest {
         when(mockTraceHeader.getDefaultDataWidthInBytes()).thenReturn(8);
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
-        CompactEventReader.Reader reader = ThreadSyncReader.createReader(CompactEventReader.ThreadSyncType.SWITCH);
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        CompactEventReader.Reader reader =
+                ThreadSyncReader.createReader(CompactEventReader.ThreadSyncType.SWITCH);
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -57,9 +60,10 @@ public class ThreadSyncReaderTest {
                 .putInt(THREAD_ID).putLong(Long.MAX_VALUE);
         buffer.rewind();
 
-        CompactEventReader.Reader reader = ThreadSyncReader.createReader(CompactEventReader.ThreadSyncType.SWITCH);
+        CompactEventReader.Reader reader =
+                ThreadSyncReader.createReader(CompactEventReader.ThreadSyncType.SWITCH);
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertEquals(1, events.size());
         Assert.assertEquals(mockCompactEvent, events.get(0));

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/UnblockSignalsReaderTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/log/compact/readers/UnblockSignalsReaderTest.java
@@ -1,12 +1,12 @@
 package com.runtimeverification.rvpredict.log.compact.readers;
 
 import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
-import com.runtimeverification.rvpredict.log.compact.CompactEvent;
 import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
 import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
 import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
 import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+import com.runtimeverification.rvpredict.testutils.ReaderUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,7 +15,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -35,7 +34,7 @@ public class UnblockSignalsReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = UnblockSignalsReader.createReader();
-        Assert.assertEquals(4, reader.size(mockTraceHeader));
+        Assert.assertEquals(4, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
 
@@ -45,7 +44,7 @@ public class UnblockSignalsReaderTest {
         when(mockTraceHeader.getPointerWidthInBytes()).thenReturn(4);
 
         CompactEventReader.Reader reader = UnblockSignalsReader.createReader();
-        Assert.assertEquals(8, reader.size(mockTraceHeader));
+        Assert.assertEquals(8, ReaderUtils.firstPartSize(reader, mockTraceHeader));
     }
 
     @Test
@@ -61,7 +60,7 @@ public class UnblockSignalsReaderTest {
 
         CompactEventReader.Reader reader = UnblockSignalsReader.createReader();
         List<ReadonlyEventInterface> events =
-                reader.readEvent(mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
+                ReaderUtils.readSimpleEvent(reader, mockContext, mockCompactEventFactory, mockTraceHeader, buffer);
 
         Assert.assertTrue(EVENT_LIST == events);
     }

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/order/JavaHappensBeforeRaceDetectorTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/order/JavaHappensBeforeRaceDetectorTest.java
@@ -7,6 +7,7 @@ import com.runtimeverification.rvpredict.log.compact.Context;
 import com.runtimeverification.rvpredict.metadata.Metadata;
 import com.runtimeverification.rvpredict.testutils.TraceUtils;
 import com.runtimeverification.rvpredict.trace.RawTrace;
+import com.runtimeverification.rvpredict.trace.SharedLibraries;
 import com.runtimeverification.rvpredict.trace.ThreadInfos;
 import com.runtimeverification.rvpredict.trace.Trace;
 import com.runtimeverification.rvpredict.trace.TraceState;
@@ -24,9 +25,11 @@ import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static com.runtimeverification.rvpredict.testutils.TraceUtils.extractEventByType;
 import static com.runtimeverification.rvpredict.testutils.TraceUtils.extractSingleEvent;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +64,7 @@ public class JavaHappensBeforeRaceDetectorTest {
         when(mockContext.createUniqueDataAddressId(ADDRESS_3_VOLATILE)).thenReturn(4L);
         when(mockMetadata.isVolatile(anyLong())).
                 then(invocation -> invocation.getArguments()[0].equals(Long.valueOf(4L)));
-        when(mockMetadata.getLocationSig(anyLong())).thenReturn("unknown location");
+        when(mockMetadata.getLocationSig(anyLong(), any())).thenReturn("unknown location");
         Logger logger = new Logger();
         try {
             logger.setLogDir("/tmp");

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/CompactEventTestUtils.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/CompactEventTestUtils.java
@@ -1,6 +1,6 @@
 package com.runtimeverification.rvpredict.testutils;
 
 public class CompactEventTestUtils {
-    public static final byte[] CURRENT_VERSION = new byte[] {0, 0, 0, 3};
-    public static final byte[] UNSUPPORTED_VERSION = new byte[] {0, 0, 0, 1};
+    public static final byte[] CURRENT_VERSION = new byte[] {0, 0, 0, 4};
+    public static final byte[] UNSUPPORTED_VERSION = new byte[] {0, 0, 0, 3};
 }

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/ReaderUtils.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/ReaderUtils.java
@@ -1,0 +1,29 @@
+package com.runtimeverification.rvpredict.testutils;
+
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.log.compact.CompactEventFactory;
+import com.runtimeverification.rvpredict.log.compact.CompactEventReader;
+import com.runtimeverification.rvpredict.log.compact.Context;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.log.compact.TraceHeader;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class ReaderUtils {
+    public static List<ReadonlyEventInterface> readSimpleEvent(
+            CompactEventReader.Reader reader,
+            Context context,
+            CompactEventFactory compactEventFactory,
+            TraceHeader header,
+            ByteBuffer buffer) throws InvalidTraceDataException {
+        while (reader.stillHasPartsToRead()) {
+            reader.addPart(buffer, header);
+        }
+        return reader.build(context, compactEventFactory, header);
+    }
+    public static int firstPartSize(
+            CompactEventReader.Reader reader, TraceHeader header) throws InvalidTraceDataException {
+        return reader.nextPartSize(header);
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/TraceUtils.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/testutils/TraceUtils.java
@@ -183,6 +183,16 @@ public class TraceUtils {
         return compactEventFactory.enterFunction(mockContext, canonicalFrameAddress, callSiteAddress);
     }
 
+    public List<ReadonlyEventInterface> sharedLibrary(int libraryId, String libraryName) {
+        prepareContextForEvent(threadId, signalDepth);
+        return compactEventFactory.sharedLibrary(mockContext, libraryId, libraryName);
+    }
+
+    public List<ReadonlyEventInterface> sharedLibrarySegment(int libraryId, long libraryStart, int librarySize) {
+        prepareContextForEvent(threadId, signalDepth);
+        return compactEventFactory.sharedLibrarySegment(mockContext, libraryId, libraryStart,  librarySize);
+    }
+
     public static ReadonlyEventInterface extractSingleEvent(List<ReadonlyEventInterface> events) {
         Assert.assertEquals(1, events.size());
         return events.get(0);

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/trace/SharedLibrariesTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/trace/SharedLibrariesTest.java
@@ -1,0 +1,35 @@
+package com.runtimeverification.rvpredict.trace;
+
+import com.google.common.collect.ImmutableList;
+import com.runtimeverification.rvpredict.log.compact.readers.SharedLibrarySegment;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class SharedLibrariesTest {
+    @Test
+    public void noAddressFoundWithoutLibraries() {
+        SharedLibraries sharedLibraries = new SharedLibraries();
+        Assert.assertFalse(sharedLibraries.getSharedLibraryNameFromAddress(11).isPresent());
+    }
+
+    @Test
+    public void noAddressFoundOneLibraryWithoutSegments() {
+        SharedLibraries sharedLibraries = new SharedLibraries();
+        SharedLibrary sharedLibrary = new SharedLibrary("test", ImmutableList.of());
+        sharedLibraries.addAll(Collections.singletonList(sharedLibrary));
+        Assert.assertFalse(sharedLibraries.getSharedLibraryNameFromAddress(11).isPresent());
+    }
+
+    @Test
+    public void addressFoundOneLibraryWithSegment() {
+        SharedLibraries sharedLibraries = new SharedLibraries();
+        SharedLibrary.Segment segment = new SharedLibrary.Segment(10, 20);
+        SharedLibrary sharedLibrary = new SharedLibrary("test", ImmutableList.of(segment));
+        sharedLibraries.addAll(Collections.singletonList(sharedLibrary));
+        Assert.assertTrue(sharedLibraries.getSharedLibraryNameFromAddress(11).isPresent());
+        Assert.assertEquals("test", sharedLibraries.getSharedLibraryNameFromAddress(11).get());
+        Assert.assertFalse(sharedLibraries.getSharedLibraryNameFromAddress(21).isPresent());
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/trace/SharedLibraryTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/trace/SharedLibraryTest.java
@@ -1,0 +1,23 @@
+package com.runtimeverification.rvpredict.trace;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SharedLibraryTest {
+    @Test
+    public void noAddressFoundOneLibraryWithoutSegments() {
+        SharedLibrary sharedLibrary = new SharedLibrary("test", ImmutableList.of());
+        Assert.assertFalse(sharedLibrary.containsAddress(11));
+    }
+
+    @Test
+    public void addressFoundOneLibraryWithSegment() {
+        SharedLibrary.Segment segment = new SharedLibrary.Segment(10, 20);
+        SharedLibrary sharedLibrary = new SharedLibrary("test", ImmutableList.of(segment));
+        Assert.assertTrue(sharedLibrary.containsAddress(11));
+        Assert.assertFalse(sharedLibrary.containsAddress(21));
+        Assert.assertTrue(segment.containsAddress(11));
+        Assert.assertFalse(segment.containsAddress(21));
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/trace/producers/base/SharedLibrariesTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/trace/producers/base/SharedLibrariesTest.java
@@ -1,0 +1,98 @@
+package com.runtimeverification.rvpredict.trace.producers.base;
+
+import com.runtimeverification.rvpredict.log.compact.Context;
+import com.runtimeverification.rvpredict.producerframework.ComputingProducerWrapper;
+import com.runtimeverification.rvpredict.producerframework.TestProducerModule;
+import com.runtimeverification.rvpredict.testutils.TraceUtils;
+import com.runtimeverification.rvpredict.trace.RawTrace;
+import com.runtimeverification.rvpredict.trace.SharedLibrary;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static com.runtimeverification.rvpredict.testutils.MoreAsserts.hasSize;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SharedLibrariesTest {
+    private static final int NO_SIGNAL = 0;
+    private static final long BASE_ID = 101L;
+    private static final long THREAD_1 = 201L;
+    private static final long PC_BASE = 301L;
+    private static final int LIBRARY_ID_1 = 401;
+    private static final int LIBRARY_START = 501;
+    private static final int LIBRARY_SIZE = 601;
+    private static final String LIBRARY_NAME_1 = "library-name-1";
+
+    @Mock private RawTraces mockRawTraces;
+    @Mock private Context mockContext;
+
+    private int nextIdDelta = 0;
+    private TestProducerModule module;
+
+    @Before
+    public void setUp() {
+        nextIdDelta = 0;
+        when(mockContext.newId()).then(invocation -> BASE_ID + nextIdDelta++);
+        module = new TestProducerModule();
+    }
+
+    @Test
+    public void noLibrariesWithoutLibrariesInTrace() {
+        ComputingProducerWrapper<SharedLibraries> sharedLibraries = createProducer(mockRawTraces);
+
+        when(mockRawTraces.getTraces()).thenReturn(Collections.emptyList());
+        SharedLibraries computed = sharedLibraries.getComputed();
+        Assert.assertTrue(computed.getLibraries().isEmpty());
+    }
+
+    @Test
+    public void buildsLibrary() {
+        ComputingProducerWrapper<SharedLibraries> sharedLibraries = createProducer(mockRawTraces);
+
+        TraceUtils tu = new TraceUtils(mockContext, THREAD_1, NO_SIGNAL, PC_BASE);
+        RawTrace rawTrace = tu.createRawTrace(tu.sharedLibrary(LIBRARY_ID_1, LIBRARY_NAME_1));
+
+        when(mockRawTraces.getTraces()).thenReturn(Collections.singletonList(rawTrace));
+        SharedLibraries computed = sharedLibraries.getComputed();
+        Assert.assertThat(computed.getLibraries(), hasSize(1));
+        SharedLibrary library = computed.getLibraries().iterator().next();
+        Assert.assertFalse(library.containsAddress(LIBRARY_START - 1));
+        Assert.assertFalse(library.containsAddress(LIBRARY_START + 1));
+        Assert.assertFalse(library.containsAddress(LIBRARY_START + LIBRARY_SIZE - 1));
+        Assert.assertFalse(library.containsAddress(LIBRARY_START + LIBRARY_SIZE + 1));
+        Assert.assertEquals(LIBRARY_NAME_1, library.getName());
+    }
+
+    @Test
+    public void buildsLibraryWithSegments() {
+        ComputingProducerWrapper<SharedLibraries> sharedLibraries = createProducer(mockRawTraces);
+
+        TraceUtils tu = new TraceUtils(mockContext, THREAD_1, NO_SIGNAL, PC_BASE);
+        RawTrace rawTrace = tu.createRawTrace(
+                tu.sharedLibrary(LIBRARY_ID_1, LIBRARY_NAME_1),
+                tu.sharedLibrarySegment(LIBRARY_ID_1, LIBRARY_START, LIBRARY_SIZE));
+
+        when(mockRawTraces.getTraces()).thenReturn(Collections.singletonList(rawTrace));
+        SharedLibraries computed = sharedLibraries.getComputed();
+        Assert.assertThat(computed.getLibraries(), hasSize(1));
+        SharedLibrary library = computed.getLibraries().iterator().next();
+        Assert.assertFalse(library.containsAddress(LIBRARY_START - 1));
+        Assert.assertTrue(library.containsAddress(LIBRARY_START + 1));
+        Assert.assertTrue(library.containsAddress(LIBRARY_START + LIBRARY_SIZE - 1));
+        Assert.assertFalse(library.containsAddress(LIBRARY_START + LIBRARY_SIZE + 1));
+        Assert.assertEquals(LIBRARY_NAME_1, library.getName());
+    }
+
+    private ComputingProducerWrapper<SharedLibraries> createProducer(
+            RawTraces rawTraces) {
+        return new ComputingProducerWrapper<>(
+                new SharedLibraries(new ComputingProducerWrapper<>(rawTraces, module)),
+                module);
+    }
+}

--- a/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/violation/RaceTest.java
+++ b/rv-predict-source/src/test/java/com/runtimeverification/rvpredict/violation/RaceTest.java
@@ -29,7 +29,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,7 +62,7 @@ public class RaceTest {
         nextIdDelta = 0;
         when(mockContext.newId()).then(invocation -> BASE_ID + nextIdDelta++);
         when(mockContext.createUniqueDataAddressId(ADDRESS_1)).thenReturn(2L);
-        when(mockMetadata.getLocationSig(anyLong())).thenReturn("");
+        when(mockMetadata.getLocationSig(anyLong(), any())).thenReturn("");
         when(mockMetadata.getVariableSig(anyLong())).thenReturn("");
         when(mockConfiguration.isCompactTrace()).thenReturn(true);
         when(mockConfiguration.isLLVMPrediction()).thenReturn(true);
@@ -144,9 +146,9 @@ public class RaceTest {
 
         Trace trace = traceState.initNextTraceWindow(rawTraces);
 
-        when(mockMetadata.getLocationSig(CALL_SITE_ADDRESS_1)).thenReturn("<call site address 1>");
-        when(mockMetadata.getLocationSig(CALL_SITE_ADDRESS_2)).thenReturn("<call site address 2>");
-        when(mockMetadata.getLocationSig(PROGRAM_COUNTER_1)).thenReturn("<thread 2 creation address>");
+        when(mockMetadata.getLocationSig(eq(CALL_SITE_ADDRESS_1), any())).thenReturn("<call site address 1>");
+        when(mockMetadata.getLocationSig(eq(CALL_SITE_ADDRESS_2), any())).thenReturn("<call site address 2>");
+        when(mockMetadata.getLocationSig(eq(PROGRAM_COUNTER_1), any())).thenReturn("<thread 2 creation address>");
         when(mockMetadata.getParentOTID(THREAD_2)).thenReturn(THREAD_1);
         when(mockMetadata.getOriginalThreadCreationLocId(THREAD_2)).thenReturn(PROGRAM_COUNTER_1);
 
@@ -212,12 +214,12 @@ public class RaceTest {
 
         Trace trace = traceState.initNextTraceWindow(rawTraces);
 
-        when(mockMetadata.getLocationSig(CALL_SITE_ADDRESS_1)).thenReturn("<method 1 call site somewhere>");
-        when(mockMetadata.getLocationSig(CALL_SITE_ADDRESS_2)).thenReturn("<method 3 call site in method 2>");
-        when(mockMetadata.getLocationSig(PROGRAM_COUNTER_1)).thenReturn("<method 1 start>");
-        when(mockMetadata.getLocationSig(PROGRAM_COUNTER_2)).thenReturn("<method 2 start>");
-        when(mockMetadata.getLocationSig(PROGRAM_COUNTER_3)).thenReturn("<method 3 start>");
-        when(mockMetadata.getLocationSig(PROGRAM_COUNTER_4)).thenReturn("<instruction 4 in method 3>");
+        when(mockMetadata.getLocationSig(eq(CALL_SITE_ADDRESS_1), any())).thenReturn("<method 1 call site somewhere>");
+        when(mockMetadata.getLocationSig(eq(CALL_SITE_ADDRESS_2), any())).thenReturn("<method 3 call site in method 2>");
+        when(mockMetadata.getLocationSig(eq(PROGRAM_COUNTER_1), any())).thenReturn("<method 1 start>");
+        when(mockMetadata.getLocationSig(eq(PROGRAM_COUNTER_2), any())).thenReturn("<method 2 start>");
+        when(mockMetadata.getLocationSig(eq(PROGRAM_COUNTER_3), any())).thenReturn("<method 3 start>");
+        when(mockMetadata.getLocationSig(eq(PROGRAM_COUNTER_4), any())).thenReturn("<instruction 4 in method 3>");
 
         Race race = new Race(extractSingleEvent(e1), extractSingleEvent(e2), trace, mockConfiguration);
         race.setFirstSignalStack(Collections.emptyList());
@@ -269,8 +271,8 @@ public class RaceTest {
 
         when(mockMetadata.getLockSig(extractSingleEvent(e3), trace))
                 .thenReturn("<mock lock representation>");
-        when(mockMetadata.getLocationSig(CALL_SITE_ADDRESS_1)).thenReturn("<call site address 1>");
-        when(mockMetadata.getLocationSig(PROGRAM_COUNTER_1)).thenReturn("<lock acquire address>");
+        when(mockMetadata.getLocationSig(eq(CALL_SITE_ADDRESS_1), any())).thenReturn("<call site address 1>");
+        when(mockMetadata.getLocationSig(eq(PROGRAM_COUNTER_1), any())).thenReturn("<lock acquire address>");
 
         Race race = new Race(extractSingleEvent(e1), extractSingleEvent(e2), trace, mockConfiguration);
         race.setFirstSignalStack(Collections.emptyList());


### PR DESCRIPTION
Sample output for lpcq. Note the extra pipes in the stack addresses.

-- Window 1 --
-- Window 2 --
Data race on [0x000000000177fcf0 : 0x0000000000401ee2/0x00007fcca4d72c80]:
    Read in thread 2
      > {0x0000000000401f90|}
        {0x0000000000402c5e|}
        {0x000000000040a0c6|}
    Thread 2 created by thread 1
        {0x00000000004028fd|}

    Write in thread 1
      > {0x0000000000402189|}
        {0x0000000000403078|}
        {0x0000000000402a13|}
        {0x00007fcca62b5830|/lib/x86_64-linux-gnu/libc.so.6}
    Thread 1 is the main thread


Data race on [0x00007ffe9c252018 : 0x0000000000402fb5/0x00007ffe9c251e60 0x00000000004024de/0x00007ffe9c252050]:
    Read in thread 2
      > {0x0000000000401f0d|}
        {0x0000000000402c5e|}
        {0x000000000040a0c6|}
    Thread 2 created by thread 1
        {0x00000000004028fd|}

    Write in thread 1
      > {0x0000000000402162|}
        {0x0000000000403078|}
        {0x0000000000402a13|}
        {0x00007fcca62b5830|/lib/x86_64-linux-gnu/libc.so.6}
    Thread 1 is the main thread
