### PR TITLE
Always add an empty line between the stack traces.

### DIFF
--- a/errors/rv-error/src/main/ocaml/base_renderer.ml
+++ b/errors/rv-error/src/main/ocaml/base_renderer.ml
@@ -151,14 +151,15 @@ let render_trace (buffer : rv_buffer) (trace : stack_trace) : unit =
     | None ->
       add_line buffer   "    Thread " ;
       add_string buffer thread_id ;
-      add_string buffer " is the main thread"
+      add_string buffer " is the main thread" ;
+      add_line buffer ""
     | Some by ->
       add_line buffer   "    Thread " ;
       add_string buffer thread_id ;
       add_string buffer " created by thread ";
       add_string buffer by ;
       match trace.thread_created_at with
-      | None -> ()
+      | None -> add_line buffer ""
       | Some frame ->
         let start_state = { numElided = 0; start = "  > in" } in
         ignore (render_frame buffer start_state frame) ;


### PR DESCRIPTION
This makes the report for examples/c11/raceless-signal look better.