### PR TITLE
Stop rvplicense from complaining that it cannot find class com.runtimeverification.environment.SetupEnvironment

### DIFF
--- a/jar/proguard.conf
+++ b/jar/proguard.conf
@@ -15,6 +15,10 @@
   static java.lang.String createAgentArgs(java.util.Collection);
 }
 
+-keep public class com.runtimeverification.environment.SetupEnvironment {
+  public static void main(java.lang.String[]);
+}
+
 -keep public class com.runtimeverification.rvpredict.engine.main.GUIMain {
   public static void main(java.lang.String[]);
 }


### PR DESCRIPTION
Exclude com.runtimeverification.environment.SetupEnvironment from the obfuscation so that rvplicense can find the entry point.