### PR TITLE
Make more of the addresses in the `unaligned` test symbolizable so

### DIFF
--- a/ctests/trace/unaligned/expect.out
+++ b/ctests/trace/unaligned/expect.out
@@ -1,10 +1,10 @@
 tid 1.0 {} begin thread generation 0
 tid 1.0 in main at .../unaligned/unaligned.c:19 enter function cfa . return {}
-tid 1.0 in main at .../unaligned/unaligned.c:20 load 4 0x00000500 <- [0x0000000040fcb4]
+tid 1.0 in main at .../unaligned/unaligned.c:20 load 4 0x00000500 <- initial.misalign at unaligned.c
 tid 1.0 in main at .../unaligned/unaligned.c:20 store 4 0x00000500 -> p.misalign at unaligned.c;main
-tid 1.0 in main at .../unaligned/unaligned.c:20 load 4 0x00000700 <- [0x0000000040fcb8]
+tid 1.0 in main at .../unaligned/unaligned.c:20 load 4 0x00000700 <- initial.a at unaligned.c
 tid 1.0 in main at .../unaligned/unaligned.c:20 store 4 0x00000700 -> p.a at unaligned.c;main
-tid 1.0 in main at .../unaligned/unaligned.c:20 load 1 00 <- [0x0000000040fcbc]
+tid 1.0 in main at .../unaligned/unaligned.c:20 load 1 00 <- initial.b at unaligned.c
 tid 1.0 in main at .../unaligned/unaligned.c:20 store 1 00 -> p.b at unaligned.c;main
 tid 1.0 in main at .../unaligned/unaligned.c:23 load 4 0x00000005 <- p.a at unaligned.c;main
 tid 1.0 in main at .../unaligned/unaligned.c:23 load 4 0x00000007 <- p.b at unaligned.c;main

--- a/ctests/trace/unaligned/unaligned.c
+++ b/ctests/trace/unaligned/unaligned.c
@@ -14,10 +14,13 @@ struct _pair {
 	uint32_t b;
 } __packed;
 
+static const pair_t initial = {.a = 5, .b = 7};
+
+#line 17
 int
 main(void)
 {
-	volatile pair_t p = {.a = 5, .b = 7};
+	volatile pair_t p = initial;
 
 	printf("%" PRIu32 " * %" PRIu32 " = %" PRIu32 "\n",
 	    p.a, p.b, p.a * p.b);


### PR DESCRIPTION
that fewer hex addresses appear in the output.  Update the test output
to match.