### PR TITLE
Comment out the LicenseChecker.validateOrDie function

### DIFF
--- a/java/src/main/java/com/runtimeverification/rvpredict/engine/main/LicenseChecker.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/engine/main/LicenseChecker.java
@@ -10,8 +10,6 @@ import static com.runtimeverification.licensing.Licensing.LICENSE_URL;
 
 public class LicenseChecker {
     public static void validateOrDie(boolean promptForLicense) {
-        return; 
-        /* @rv: Disable licensing check.  
         Licensing licensingSystem = Licensing.fromLocations(
                 "predict",
                 Licensing.LicenseLocation.USER_DIRECTORY,
@@ -30,7 +28,6 @@ public class LicenseChecker {
         if (licensingSystem.getLicenseStatus() != Licensing.LicenseStatus.VALID) {
             System.exit(1);
         }
-        */
     }
 
     private static String errorMessage(Licensing.LicenseStatus licenseStatus) {

--- a/java/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/engine/main/Main.java
@@ -28,7 +28,7 @@ public class Main {
     public static void main(String[] args) {
         config = Configuration.instance(args);
 
-        LicenseChecker.validateOrDie(config.prompt_for_license);
+        // LicenseChecker.validateOrDie(config.prompt_for_license);
 
         if (config.isLogging() || config.isProfiling()) {
             if (config.getJavaArguments().isEmpty()) {

--- a/java/src/main/java/com/runtimeverification/rvpredict/instrument/Agent.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/instrument/Agent.java
@@ -125,7 +125,7 @@ public class Agent implements ClassFileTransformer, Constants {
     }
 
     private static void printStartupInfo() {
-        LicenseChecker.validateOrDie(config.prompt_for_license);
+        // LicenseChecker.validateOrDie(config.prompt_for_license);
         config.logger().reportPhase(Configuration.INSTRUMENTED_EXECUTION_TO_RECORD_THE_TRACE);
         if (config.getLogDir() != null) {
             config.logger().report("Log directory: " + config.getLogDir(), Logger.MSGTYPE.INFO);


### PR DESCRIPTION
@gnuoyd @virgil-serbanuta 

Virgil said:

> As I said in my previous request: Although it is slightly more comfortable to comment out this code, I think that validateOrDie should validate or die. There is a stronger case here for commenting out the code, but I still think that any of the following is better:
> * creating a new maybeValidateOrDie that checks a global constant and, depending on that, may call validateOrDie.
> * commenting out the caller code.
> * renaming this method to "maybeValidateOrDie" and using the same global constant.

I chose the second way ` commenting out the caller code.`.
Yes, I think @virgil-serbanuta is right. I shouldn't change the meaning of a function. So I changed `validateOrDie` function back. 

Thank you
