### PR TITLE
When the runtime wait(2)ed for the program to finish and automatically

### DIFF
--- a/llvm/ngrt/supervise.c
+++ b/llvm/ngrt/supervise.c
@@ -242,6 +242,15 @@ rvp_supervision_start(void)
 		    product_name);
 	}
 
+	if (WIFSIGNALED(status)) {
+		fprintf(stderr, "%s", strsignal(WTERMSIG(status)));
+#ifdef WCOREDUMP
+		if (WCOREDUMP(status))
+			fprintf(stderr, " (core dumped)");
+#endif /* WCOREDUMP */
+		fputc('\n', stderr);
+	}
+
 	if ((pid = fork()) == -1) {
 		err(EXIT_FAILURE,
 		    "%s could not fork an analysis process", product_name);


### PR DESCRIPTION
performed data-race analysis, nothing like "Segmentation fault (core
dumped)" would ever appear on the console.  That was a bit misleading:
programs that received an unhandled signal died silently.  With this
change, the runtime prints information about any signal (and any core
dump) before running the analysis.