### PR TITLE
Fix c-installer dependency bug

### DIFF
--- a/c-installer/scripts/install.sh
+++ b/c-installer/scripts/install.sh
@@ -5,5 +5,6 @@ set -e
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
+apt-get update
 sh -c "RV_PREDICT_LICENSE_ACCEPTED='yes' dpkg -i \"$SCRIPTPATH/../rv-predict-c-$1.deb\"" || apt-get install -f -y
 sh -c "RV_PREDICT_LICENSE_ACCEPTED='yes' dpkg -i \"$SCRIPTPATH/../rv-predict-c-$1.deb\""


### PR DESCRIPTION
This pull request should fix the issue that c-installer failed to install dependencies.
If you compare Jenkins job [rv-predict-pull-request #93](https://office.runtimeverification.com/jenkins/job/rv-predict-master/93/console) with [rv-predict-master #93](https://office.runtimeverification.com/jenkins/job/rv-predict-master/93/console) (search for `linux-libc-dev`), you would see that `rv-predict-master` was downloading dependencies from invalid url. ( I think `rv-predict-pull-request` didn't have that problem because at that time the remote archives were correct and no need to be updated)
Therefore, running `apt-get update` at start is necessary.
I will close [pull request #864](https://github.com/runtimeverification/rv-predict/pull/864) now.

Now the only prerequisite to install rv-predict/c is `Java8`.