### PR TITLE
Fix README.md in tests/examples

### DIFF
--- a/tests/examples/README.md
+++ b/tests/examples/README.md
@@ -25,9 +25,6 @@ or
 
     java -javaagent:../lib/rv-predict.jar -cp examples.jar account.Account
 
-Read the RV-Predict documentation and blog articles reachable from the
-[RV-Predict website](http://runtimeverification.com/predict).
-https://runtimeverification.com/predict for more details.  Contact us using
-the [Runtime Verification Support](http://runtimeverification.com/support)
-page for problems, comments, suggestions.
+Read the RV-Predict documentation and blog articles reachable from the [RV-Predict website](http://runtimeverification.com/predict) for more details.    
+Contact us using the [Runtime Verification Support](http://runtimeverification.com/support) page for problems, comments, suggestions.
 


### PR DESCRIPTION
**[The old README](https://github.com/runtimeverification/rv-predict/blob/master/tests/examples/README.md)**:

<img width="938" alt="screen shot 2018-03-06 at 3 33 34 pm" src="https://user-images.githubusercontent.com/1908863/37059736-ce196d88-2153-11e8-9919-df88727de86a.png">

You could see there is an extra line `https://runtimeverification.com/predict for more details`.  

---

**[The new README](https://github.com/shd101wyy/rv-predict/blob/fix-rvpredict-java-examples-readme/tests/examples/README.md)**:

<img width="929" alt="screen shot 2018-03-06 at 3 33 46 pm" src="https://user-images.githubusercontent.com/1908863/37059769-e3990e7a-2153-11e8-99cc-ad15620dec1c.png">

