### PR TITLE
Add a flag to `rvpa` that performs no analysis but prints the java

### DIFF
--- a/scripts/rvpa.1
+++ b/scripts/rvpa.1
@@ -10,6 +10,7 @@ instrumentation using
 .Sh SYNOPSIS
 .Nm 
 .Op Fl h
+.Op Fl n
 .Op Fl Fl help
 .Op Fl Fl window Ar size
 .Op Fl Fl no-shorten
@@ -52,7 +53,10 @@ Command-line options modify the behavior of
 .Nm :
 .Bl -tag -width "mmprompt-for-license"
 .It Fl h | Fl Fl help
-Print a help message. 
+Print a help message and exit immediately.
+.It Fl n
+Print the Java command that would be run.
+Perform no analysis.
 .It Fl Fl window Ar size
 .Tn RV-Predict/C
 segments
@@ -251,7 +255,7 @@ but the version is not late enough.
 .Xr rvpx 1
 .Sh HISTORY
 .Tn RV-Predict/C
-1.9 was released in January 2018.
+1.9 was released in February 2018.
 .Sh AUTHORS
 .\" .An "Yilong Li"
 .\" .An "Traian Serbanuta"

--- a/scripts/rvpa.sh
+++ b/scripts/rvpa.sh
@@ -3,6 +3,7 @@
 set -e
 set -u
 
+only_print_command=no
 analyze_passthrough=
 symbolize_passthrough=
 sharedir=$(dirname $0)/../share/rv-predict-c
@@ -35,11 +36,16 @@ EOF
 
 rvpredict()
 {
-	if which java >/dev/null; then
+	pfx=
+
+	if [ ${only_print_command:-no} = yes ]; then
+		pfx=echo
+		_java=java
+	elif which java >/dev/null; then
 		# found java executable in PATH
 		_java=java
 	elif [ "${JAVA_HOME:-}/bin/java" != "/bin/java" -a \
-	       -x "${JAVA_HOME:-}/bin/java" ];  then
+	       -x "${JAVA_HOME:-}/bin/java" ]; then
 		# found java executable in JAVA_HOME
 		_java="${JAVA_HOME:-}/bin/java"
 	else
@@ -50,38 +56,7 @@ EOF
 		exit 2
 	fi
 
-	${_java} -ea -jar ${sharedir}/rv-predict.jar "$@"
-}
-
-trim_stack()
-{
-	# TBD suppress __rvpredict_ and rvp_ symbols first by
-	# converting to, say, ##suppressed##, then removing ##suppressed##
-	# and stanzas consisting only of ##suppressed## in a second stage
-	awk 'BEGIN { saw_stack_bottom = 0 }
-	/^ {6,6}[> ] in rvp_[a-zA-Z_][0-9a-zA-Z_]* at / {
-		saw_stack_bottom = 1
-		next
-	}
-	/^ {6,6}[> ] in __rvpredict_[a-zA-Z_][0-9a-zA-Z_]* at / {
-		saw_stack_bottom = 1
-		next
-	}
-	/^ {6,6}[> ] in main at / {
-		print
-		saw_stack_bottom = 1
-		next
-	}
-	/^ {0,7}[^ ]/ {
-		saw_stack_bottom = 0
-	}
-	/^$/ {
-		saw_stack_bottom = 0
-	}
-	{
-		if (!saw_stack_bottom)
-			print
-	}'
+	${pfx} ${_java} -ea -jar ${sharedir}/rv-predict.jar "$@"
 }
 
 symbolize()
@@ -110,6 +85,10 @@ fi
 
 while [ $# -ge 1 ]; do
 	case $1 in
+	-n)
+		only_print_command=yes
+		shift
+		;;
 	--no-symbol)
 		symbolize_passthrough="${symbolize_passthrough:-} -S"
 		shift
@@ -189,4 +168,4 @@ fi
 rvpredict ${analyze_passthrough:-} ${window:---window 2000} \
     --json-report \
     --compact-trace ${trace_file:-./rvpredict.trace} | \
-    symbolize $progpath 2>&1
+    { [ ${only_print_command:-no} = no ] && symbolize $progpath 2>&1 || cat ; }

--- a/scripts/rvpc.1
+++ b/scripts/rvpc.1
@@ -347,7 +347,7 @@ respects the definition of data races between threads given in the
 C11 standard.
 .Sh HISTORY
 .Tn RV-Predict/C
-2.0 was released in July 2017.
+1.9 was released in February 2018.
 .Sh AUTHORS
 .\" .An "Yilong Li"
 .\" .An "Traian Serbanuta"

--- a/scripts/rvpsymbolize.1
+++ b/scripts/rvpsymbolize.1
@@ -82,7 +82,7 @@ Otherwise, it returns 0.
 .Xr rvpx 1
 .Sh HISTORY
 .Tn RV-Predict/C
-2.0 was released in July 2017.
+1.9 was released in February 2018.
 .Sh AUTHORS
 .\" .An "Yilong Li"
 .\" .An "Traian Serbanuta"


### PR DESCRIPTION
command that would perform the analysis.

Correct the HISTORY sections in the manual pages.  Oops, 1.9 was released
after HISTORY says 2.0 was released.

Delete the unused function `trim_stack()` from `rvpa.