### PR TITLE
Filter command-line arguments using some code borrowed from NetBSD's

### DIFF
--- a/scripts/rvpc.sh.in
+++ b/scripts/rvpc.sh.in
@@ -7,6 +7,59 @@
 set -e
 set -u
 
+# Filter out arguments that should not be passed to the compiler.
+# Quote args to make them safe in the shell.
+# Usage: quotedlist="$(shell_quote args...)"
+#
+# Use the returned string by evaling it inside
+# double quotes, like this:
+#    eval "set -- $quotedlist"
+# or like this:
+#    eval "\$command $quotedlist \$filename"
+#
+filter_noncc_arguments()
+{(
+	local result=''
+	local arg qarg
+	LC_COLLATE=C ; export LC_COLLATE # so [a-zA-Z0-9] works in ASCII
+	for arg in "$@" ; do
+		case "${arg}" in
+		--just-print)
+			continue
+			;;
+		--intr-personality=*)
+			continue
+			;;
+		'')
+			qarg="''"
+			;;
+		*[!-./a-zA-Z0-9]*)
+			# Convert each embedded ' to '\'',
+			# then insert ' at the beginning of the first line,
+			# and append ' at the end of the last line.
+			# Finally, elide unnecessary '' pairs at the
+			# beginning and end of the result and as part of
+			# '\'''\'' sequences that result from multiple
+			# adjacent quotes in he input.
+			qarg="$(printf "%s\n" "$arg" | \
+			    ${SED:-sed} -e "s/'/'\\\\''/g" \
+				-e "1s/^/'/" -e "\$s/\$/'/" \
+				-e "1s/^''//" -e "\$s/''\$//" \
+				-e "s/'''/'/g"
+				)"
+			;;
+		*)
+			# Arg is not the empty string, and does not contain
+			# any unsafe characters.  Leave it unchanged for
+			# readability.
+			qarg="${arg}"
+			;;
+		esac
+		result="${result}${result:+ }${qarg}"
+	done
+	printf "%s\n" "$result"
+)}
+
 ldscript_dir=$(dirname $0)/../share/rv-predict-c
 pass_dir=$(dirname $0)/../--LIBEXECDIR--
 runtime_dir=$(dirname $0)/../lib
@@ -70,19 +123,8 @@ for arg in "$@"; do
 	esac
 done
 
-args=
-
-for arg in "$@"; do
-	case "$arg" in
-	--just-print)
-		;;
-	--intr-personality=*)
-		;;
-	*)
-		args="${args} ${arg}"
-		;;
-	esac
-done
+quoted_list=$(filter_noncc_arguments "$@")
+eval "set -- ${quoted_list}"
 
 if [ ${cplusplus:-no} = yes ]; then
 	compiler="clang++-4.0 -std=c++11"
@@ -112,4 +154,4 @@ else
 	pfx=
 fi
 
-$pfx $compiler ${pass:-} ${args} ${runtime:-}
+$pfx $compiler ${pass:-} "$@" ${runtime:-}


### PR DESCRIPTION
`build.sh`.  This fixes a bug where arguments contained spaces, e.g.,
Tim Swan reported in issue #906,

```
rvpc  -I/root/rv-match_testing/tests/bind9-alt/rvpc/build/bind9 -I../.. -I./include -I./unix/include -I. -I/root/rv-match_testing/tests/bind9-alt/rvpc/build/bind9/lib/ns/include -I../../lib/ns/include -I/root/rv-match_testing/tests/bind9-alt/rvpc/build/bind9/lib/dns/include -I../../lib/dns/include -I/root/rv-match_testing/tests/bind9-alt/rvpc/build/bind9/lib/bind9/include -I../../lib/bind9/include -I/root/rv-match_testing/tests/bind9-alt/rvpc/build/bind9/lib/isccfg/include -I../../lib/isccfg/include -I/root/rv-match_testing/tests/bind9-alt/rvpc/build/bind9/lib/isccc/include -I../../lib/isccc/include -I/root/rv-match_testing/tests/bind9-alt/rvpc/build/bind9/lib/isc/include -I../../lib/isc -I../../lib/isc/include -I../../lib/isc/unix/include -I../../lib/isc/pthreads/include -I../../lib/isc/x86_32/include    -I/root/rv/bind9/unit/atf/include -D_REENTRANT -DOPENSSL -D_GNU_SOURCE -DNS_HOOKS_ENABLE=1 -g -O2 -I/usr/include/libxml2   -fPIC  -W -Wall -Wmissing-prototypes -Wcast-qual -Wwrite-strings -Wformat -Wpointer-arith -fno-strict-aliasing  \
	-DVERSION=\"9.12.0b1\" \
	-DPRODUCT=\""BIND"\" \
	-DDESCRIPTION=\"""\" \
	-DSRCID=\"63270d3\" \
	-DCONFIGARGS="\"'--prefix=/root/bind9' '--host=x86_64-linux-gnu' '--build=x86_64-pc-linux-gnu' '--with-randomdev=/dev/random' '--with-ecdsa=yes' '--with-gost=yes' '--with-eddsa=no' '--with-atf=/root/rv/bind9/unit/atf' 'BUILD_CC=gcc' 'CC=rvpc' 'CXX=rvpc++' 'build_alias=x86_64-pc-linux-gnu' 'host_alias=x86_64-linux-gnu'\"" \
	-DBUILDER="\"make\"" \
	-DNAMED_LOCALSTATEDIR=\"/root/bind9/var\" \
	-DNAMED_SYSCONFDIR=\"/root/bind9/etc\" -c ./main.c
clang: error: no such file or directory: ''--host=x86_64-linux-gnu''
clang: error: no such file or directory: ''--build=x86_64-pc-linux-gnu''
clang: error: no such file or directory: ''--with-randomdev=/dev/random''
clang: error: no such file or directory: ''--with-ecdsa=yes''
clang: error: no such file or directory: ''--with-gost=yes''
clang: error: no such file or directory: ''--with-eddsa=no''
clang: error: no such file or directory: ''--with-atf=/root/rv/bind9/unit/atf''
clang: error: no such file or directory: ''BUILD_CC=gcc''
clang: error: no such file or directory: ''CC=rvpc''
clang: error: no such file or directory: ''CXX=rvpc++''
clang: error: no such file or directory: ''build_alias=x86_64-pc-linux-gnu''
clang: error: no such file or directory: ''host_alias=x86_64-linux-gnu'"'
Makefile:501: recipe for target 'main.o' failed
```