### PR TITLE
Nightly release support

### DIFF
--- a/c-installer/pom.xml
+++ b/c-installer/pom.xml
@@ -270,6 +270,9 @@
         </profile>
         <profile>
             <id>deploy</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <toDebFile>/var/www/predict/${project.version}/c/rv-predict-c_${project.version}-1_amd64.deb</toDebFile>
                 <toJarFile>/var/www/predict/${project.version}/c/rv-predict-c-installer-${project.version}.jar</toJarFile>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -105,6 +105,9 @@
     <profiles>
         <profile>
             <id>deploy</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <toDocsDir>/var/www/predict/${project.version}/docs</toDocsDir>
             </properties>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -205,6 +205,9 @@
         </profile>
         <profile>
             <id>deploy</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <toJarFile>/var/www/predict/${project.version}/rv-predict-installer-${project.version}.jar</toJarFile>
             </properties>

--- a/web-c-docs/pom.xml
+++ b/web-c-docs/pom.xml
@@ -105,6 +105,9 @@
     <profiles>
         <profile>
             <id>deploy</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <toDocsDir>/var/www/predict/${project.version}/c/docs</toDocsDir>
             </properties>


### PR DESCRIPTION
This pull request adds profiles for nightly deployment.  
You can now trigger a nightly deployment by running with `deploy-nightly` profile:

```bash
$ mvn deploy -Pdeploy-nightly -Dobfuscate -DskipTests
```

while a normal deployment could be triggered by runningwith `deploy` profile:

```
$ mvn deploy -Dobfuscate -DskipTests
```

The nightly build will be located at `/var/www/predict/nightly` directory on `vultr` server.
The filenames are: 

* `/var/www/predict/rv-predict-installer-nightly.jar`
* `/var/www/predict/c/rv-predict-c-nightly.deb`
* `/var/www/predict/c/rv-predict-c-nightly.jar`

@gnuoyd Please let me know if you approve this pull request. I will then set up a jenkins job to deploy the nightly build every night.

Thank you
