### PR TITLE
Performance optimizations.

### DIFF
--- a/jar/src/test/java/com/runtimeverification/rvpredict/algorithm/BinarySearchTest.java
+++ b/jar/src/test/java/com/runtimeverification/rvpredict/algorithm/BinarySearchTest.java
@@ -1,0 +1,135 @@
+package com.runtimeverification.rvpredict.algorithm;
+
+import com.runtimeverification.rvpredict.testutils.MoreAsserts;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class BinarySearchTest {
+    @Test
+    public void doesNotFindKeyInEmptyList() {
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Collections.<Integer>emptyList(), i -> i, 1),
+                MoreAsserts.isAbsentInt());
+    }
+
+    @Test
+    public void doesNotFindKeyInListWithLargerElements() {
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Collections.singletonList(2), i -> i, 1),
+                MoreAsserts.isAbsentInt());
+    }
+
+    @Test
+    public void findsKeyInOneElementList() {
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Collections.singletonList(2), i -> i, 3),
+                MoreAsserts.isPresentWithIntValue(0));
+    }
+
+    @Test
+    public void all7ElementListSearches() {
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 1),
+                MoreAsserts.isAbsentInt());
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 2),
+                MoreAsserts.isPresentWithIntValue(0));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 3),
+                MoreAsserts.isPresentWithIntValue(0));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 4),
+                MoreAsserts.isPresentWithIntValue(1));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 5),
+                MoreAsserts.isPresentWithIntValue(1));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 6),
+                MoreAsserts.isPresentWithIntValue(2));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 7),
+                MoreAsserts.isPresentWithIntValue(2));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 8),
+                MoreAsserts.isPresentWithIntValue(3));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 9),
+                MoreAsserts.isPresentWithIntValue(3));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 10),
+                MoreAsserts.isPresentWithIntValue(4));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 11),
+                MoreAsserts.isPresentWithIntValue(4));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 12),
+                MoreAsserts.isPresentWithIntValue(5));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 13),
+                MoreAsserts.isPresentWithIntValue(5));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 14),
+                MoreAsserts.isPresentWithIntValue(6));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14), i -> i, 15),
+                MoreAsserts.isPresentWithIntValue(6));
+    }
+
+    @Test
+    public void all8ElementListSearches() {
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 1),
+                MoreAsserts.isAbsentInt());
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 2),
+                MoreAsserts.isPresentWithIntValue(0));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 3),
+                MoreAsserts.isPresentWithIntValue(0));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 4),
+                MoreAsserts.isPresentWithIntValue(1));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 5),
+                MoreAsserts.isPresentWithIntValue(1));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 6),
+                MoreAsserts.isPresentWithIntValue(2));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 7),
+                MoreAsserts.isPresentWithIntValue(2));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 8),
+                MoreAsserts.isPresentWithIntValue(3));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 9),
+                MoreAsserts.isPresentWithIntValue(3));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 10),
+                MoreAsserts.isPresentWithIntValue(4));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 11),
+                MoreAsserts.isPresentWithIntValue(4));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 12),
+                MoreAsserts.isPresentWithIntValue(5));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 13),
+                MoreAsserts.isPresentWithIntValue(5));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 14),
+                MoreAsserts.isPresentWithIntValue(6));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 15),
+                MoreAsserts.isPresentWithIntValue(6));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 16),
+                MoreAsserts.isPresentWithIntValue(7));
+        Assert.assertThat(
+                BinarySearch.getIndexLessOrEqual(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16), i -> i, 17),
+                MoreAsserts.isPresentWithIntValue(7));
+    }
+}

--- a/jar/src/test/java/com/runtimeverification/rvpredict/testutils/TraceUtils.java
+++ b/jar/src/test/java/com/runtimeverification/rvpredict/testutils/TraceUtils.java
@@ -193,6 +193,12 @@ public class TraceUtils {
                 mockContext, Constants.INVALID_EVENT_ID, canonicalFrameAddress, callSiteAddress);
     }
 
+    public List<ReadonlyEventInterface> exitFunction() {
+        prepareContextForEvent(threadId, signalDepth);
+        return compactEventFactory.exitFunction(
+                mockContext, Constants.INVALID_EVENT_ID);
+    }
+
     public static ReadonlyEventInterface extractSingleEvent(List<ReadonlyEventInterface> events) {
         Assert.assertEquals(1, events.size());
         return events.get(0);

--- a/jar/src/test/java/com/runtimeverification/rvpredict/trace/producers/base/StackTracesTest.java
+++ b/jar/src/test/java/com/runtimeverification/rvpredict/trace/producers/base/StackTracesTest.java
@@ -1,0 +1,226 @@
+package com.runtimeverification.rvpredict.trace.producers.base;
+
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.log.compact.Context;
+import com.runtimeverification.rvpredict.log.compact.InvalidTraceDataException;
+import com.runtimeverification.rvpredict.producerframework.ComputingProducerWrapper;
+import com.runtimeverification.rvpredict.producerframework.TestProducerModule;
+import com.runtimeverification.rvpredict.testutils.TraceUtils;
+import com.runtimeverification.rvpredict.trace.RawTrace;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+
+import static com.runtimeverification.rvpredict.testutils.MoreAsserts.containsInOrder;
+import static com.runtimeverification.rvpredict.testutils.MoreAsserts.isEmpty;
+import static com.runtimeverification.rvpredict.testutils.TraceUtils.extractSingleEvent;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StackTracesTest {
+    private static final int NO_SIGNAL = 0;
+    private static final int TTID_1 = 101;
+    private static final long EVENT_ID_1 = 201L;
+    private static final long BASE_ID = 301L;
+    private static final long THREAD_ID_1 = 401L;
+    private static final long PC_BASE = 501L;
+    private static final long CANONICAL_FRAME_ADDRESS_1 = 601L;
+    private static final long CANONICAL_FRAME_ADDRESS_2 = 602L;
+    private static final long CANONICAL_FRAME_ADDRESS_3 = 603L;
+    private static final OptionalLong CALL_SITE_ADDRESS_1 = OptionalLong.of(701L);
+    private static final long ADDRESS_1 = 801L;
+    private static final long VALUE_1 = 901L;
+
+    @Mock private RawTraces mockRawTraces;
+
+    @Mock private Context mockContext;
+
+    private final TestProducerModule module = new TestProducerModule();
+
+    private long nextIdDelta;
+
+    @Before
+    public void setUp() {
+        nextIdDelta = 0;
+        when(mockContext.newId()).then(invocation -> BASE_ID + nextIdDelta++);
+    }
+
+    @Test
+    public void noStacksForEmptyTraces() {
+        ComputingProducerWrapper<StackTraces> producer = initProducer(module, mockRawTraces);
+        module.reset();
+
+        when(mockRawTraces.getTraces()).thenReturn(Collections.emptyList());
+
+        Assert.assertThat(
+                producer.getComputed().getStackTraceAfterEventBuilder(TTID_1, EVENT_ID_1).build(),
+                isEmpty());
+    }
+
+    @Test
+    public void addsStartedFunctionsToStack() throws InvalidTraceDataException {
+        TraceUtils tu = new TraceUtils(mockContext, THREAD_ID_1, NO_SIGNAL, PC_BASE);
+        ComputingProducerWrapper<StackTraces> producer = initProducer(module, mockRawTraces);
+        module.reset();
+
+        List<ReadonlyEventInterface> event1List;
+        List<ReadonlyEventInterface> event2List;
+        List<ReadonlyEventInterface> event3List;
+        List<ReadonlyEventInterface> event4List;
+        List<ReadonlyEventInterface> stack1List;
+        List<ReadonlyEventInterface> stack2List;
+        List<ReadonlyEventInterface> stack3List;
+        RawTrace trace = tu.createRawTrace(
+                tu.setPc(PC_BASE),
+                event1List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                stack1List = tu.enterFunction(CANONICAL_FRAME_ADDRESS_1, CALL_SITE_ADDRESS_1),
+                event2List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                stack2List = tu.enterFunction(CANONICAL_FRAME_ADDRESS_2, CALL_SITE_ADDRESS_1),
+                event3List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                stack3List = tu.enterFunction(CANONICAL_FRAME_ADDRESS_3, CALL_SITE_ADDRESS_1),
+                event4List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1)
+        );
+
+        when(mockRawTraces.getTraces()).thenReturn(Collections.singletonList(trace));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event1List),
+                isEmpty());
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event2List),
+                containsInOrder(getId(stack1List)));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event3List),
+                containsInOrder(getId(stack1List), getId(stack2List)));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event4List),
+                containsInOrder(getId(stack1List), getId(stack2List), getId(stack3List)));
+    }
+
+    @Test
+    public void removesExitedFunctionFromStack() throws InvalidTraceDataException {
+        TraceUtils tu = new TraceUtils(mockContext, THREAD_ID_1, NO_SIGNAL, PC_BASE);
+        ComputingProducerWrapper<StackTraces> producer = initProducer(module, mockRawTraces);
+        module.reset();
+
+        List<ReadonlyEventInterface> event1List;
+        List<ReadonlyEventInterface> event2List;
+        List<ReadonlyEventInterface> event3List;
+        List<ReadonlyEventInterface> event4List;
+        List<ReadonlyEventInterface> event5List;
+        List<ReadonlyEventInterface> stack1List;
+        List<ReadonlyEventInterface> stack2List;
+        List<ReadonlyEventInterface> stack3List;
+        RawTrace trace = tu.createRawTrace(
+                tu.setPc(PC_BASE),
+                event1List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                stack1List = tu.enterFunction(CANONICAL_FRAME_ADDRESS_1, CALL_SITE_ADDRESS_1),
+                event2List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                stack2List = tu.enterFunction(CANONICAL_FRAME_ADDRESS_2, CALL_SITE_ADDRESS_1),
+                event3List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                tu.exitFunction(),
+                event4List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                stack3List = tu.enterFunction(CANONICAL_FRAME_ADDRESS_3, CALL_SITE_ADDRESS_1),
+                event5List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1)
+        );
+
+        when(mockRawTraces.getTraces()).thenReturn(Collections.singletonList(trace));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event1List),
+                isEmpty());
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event2List),
+                containsInOrder(getId(stack1List)));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event3List),
+                containsInOrder(getId(stack1List), getId(stack2List)));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event4List),
+                containsInOrder(getId(stack1List)));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event5List),
+                containsInOrder(getId(stack1List), getId(stack3List)));
+    }
+
+    @Test
+    public void doesNotCrashWhenExitingTooManyFunctions() throws InvalidTraceDataException {
+        TraceUtils tu = new TraceUtils(mockContext, THREAD_ID_1, NO_SIGNAL, PC_BASE);
+        ComputingProducerWrapper<StackTraces> producer = initProducer(module, mockRawTraces);
+        module.reset();
+
+        List<ReadonlyEventInterface> event1List;
+        List<ReadonlyEventInterface> event2List;
+        List<ReadonlyEventInterface> event3List;
+        List<ReadonlyEventInterface> event4List;
+        List<ReadonlyEventInterface> stack1List;
+        RawTrace trace = tu.createRawTrace(
+                tu.setPc(PC_BASE),
+                event1List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                stack1List = tu.enterFunction(CANONICAL_FRAME_ADDRESS_1, CALL_SITE_ADDRESS_1),
+                event2List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                tu.exitFunction(),
+                event3List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1),
+                tu.exitFunction(),
+                event4List = tu.nonAtomicLoad(ADDRESS_1, VALUE_1)
+        );
+
+        when(mockRawTraces.getTraces()).thenReturn(Collections.singletonList(trace));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event1List),
+                isEmpty());
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event2List),
+                containsInOrder(getId(stack1List)));
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event3List),
+                isEmpty());
+
+        Assert.assertThat(
+                getStackTraceIDs(producer, trace, event4List),
+                isEmpty());
+    }
+
+    private static long getId(List<ReadonlyEventInterface> event) {
+        return extractSingleEvent(event).getEventId();
+    }
+
+    private static Collection<Long> getStackTraceIDs(
+            ComputingProducerWrapper<StackTraces> producer,
+            RawTrace trace,
+            List<ReadonlyEventInterface> event) {
+        return producer.getComputed().getStackTraceAfterEventBuilder(
+                trace.getThreadInfo().getId(),
+                getId(event)
+        ).build().stream().map(ReadonlyEventInterface::getEventId).collect(Collectors.toList());
+
+    }
+
+    private static ComputingProducerWrapper<StackTraces> initProducer(
+            TestProducerModule module,
+            RawTraces rawTraces) {
+        return new ComputingProducerWrapper<>(
+                new StackTraces(
+                        new ComputingProducerWrapper<>(rawTraces, module)),
+                module);
+    }
+}

--- a/java/src/main/java/com/runtimeverification/rvpredict/algorithm/BinarySearch.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/algorithm/BinarySearch.java
@@ -1,0 +1,60 @@
+package com.runtimeverification.rvpredict.algorithm;
+
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.function.Function;
+
+public class BinarySearch {
+    public static <T, K extends Comparable<K>>
+    OptionalInt getIndexLessOrEqual(List<T> elements, Function<T, K> elementToKey, K key) {
+        if (elements.isEmpty()) {
+            return OptionalInt.empty();
+        }
+        return getIndexLessOrEqualRec(
+                elements, elementToKey, key, 0, elements.size() - 1, OptionalInt.empty());
+    }
+
+    /**
+     * Searches between start and end inclusive. Returns empty() if key > elementToKey.apply(elements.get(start)).
+     *
+     * Invariant: all elements before start are strictly less than the key, all elements after end are strictly
+     * larger.
+     */
+    private static <T, K extends Comparable<K>>
+    OptionalInt getIndexLessOrEqualRec(
+            List<T> elements, Function<T, K> elementToKey, K key, int start, int end, OptionalInt lastIndexLessOrEqual) {
+        assert start <= end;
+        if (start == end) {
+            K startKey = elementToKey.apply(elements.get(start));
+            if (startKey.compareTo(key) > 0) {
+                return lastIndexLessOrEqual;
+            }
+            return OptionalInt.of(start);
+        }
+
+        if (start == end - 1) {
+            K endKey = elementToKey.apply(elements.get(end));
+            if (endKey.compareTo(key) > 0) {
+                return getIndexLessOrEqualRec(elements, elementToKey, key, start, start, lastIndexLessOrEqual);
+            }
+            return OptionalInt.of(end);
+        }
+
+        int mid = (start + end) / 2;
+        assert start < mid;
+        assert mid < end;
+
+        K midKey = elementToKey.apply(elements.get(mid));
+        int cmp = midKey.compareTo(key);
+        if (cmp > 0) {
+            return getIndexLessOrEqualRec(elements, elementToKey, key, start, mid - 1, lastIndexLessOrEqual);
+        }
+        if (cmp < 0) {
+            return getIndexLessOrEqualRec(elements, elementToKey, key, mid + 1, end, OptionalInt.of(mid));
+        }
+        // Note that, statistically speaking, this line is reached very rarely, so it would be more
+        // efficient to merge this case with one of the previous ones. However, the code is easier
+        // to read this way, and the performance difference is not that large.
+        return OptionalInt.of(mid);
+    }
+}

--- a/java/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEventFactory.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/log/compact/CompactEventFactory.java
@@ -64,8 +64,7 @@ public class CompactEventFactory {
 
     private ReadonlyEventInterface dataManipulationEvent(
             Context context, long originalEventId, int dataSizeInBytes, long dataAddress, long dataAddressId,
-            long value, EventType compactType)
-            throws InvalidTraceDataException {
+            long value, EventType compactType) {
         return new CompactEvent(context, compactType, originalEventId) {
             @Override
             int getDataSizeInBytes() {
@@ -348,8 +347,7 @@ public class CompactEventFactory {
         });
     }
 
-    public List<ReadonlyEventInterface> blockSignals(Context context, long originalEventId, long signalMaskNumber)
-            throws InvalidTraceDataException {
+    public List<ReadonlyEventInterface> blockSignals(Context context, long originalEventId, long signalMaskNumber) {
         long signalMask = context.getMemoizedSignalMask(signalMaskNumber);
         return Collections.singletonList(
                 new CompactEvent(context, EventType.BLOCK_SIGNALS, originalEventId) {
@@ -365,8 +363,7 @@ public class CompactEventFactory {
                 });
     }
 
-    public List<ReadonlyEventInterface> unblockSignals(Context context, long originalEventId, long signalMaskNumber)
-            throws InvalidTraceDataException {
+    public List<ReadonlyEventInterface> unblockSignals(Context context, long originalEventId, long signalMaskNumber) {
         long signalMask = context.getMemoizedSignalMask(signalMaskNumber);
         return Collections.singletonList(
                 new CompactEvent(context, EventType.UNBLOCK_SIGNALS, originalEventId) {
@@ -441,7 +438,7 @@ public class CompactEventFactory {
         });
     }
 
-    List<ReadonlyEventInterface> exitFunction(Context context, long originalEventId) {
+    public List<ReadonlyEventInterface> exitFunction(Context context, long originalEventId) {
         return Collections.singletonList(new CompactEvent(context, EventType.FINISH_METHOD, originalEventId) {
         });
     }

--- a/java/src/main/java/com/runtimeverification/rvpredict/smt/TransitiveClosure.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/smt/TransitiveClosure.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.tuple.Pair;
 
 
 public class TransitiveClosure {
-
     /**
      * Map from event to its group ID in the contracted graph.
      */
@@ -26,7 +25,7 @@ public class TransitiveClosure {
         this.relation = inRelation;
     }
 
-    public boolean inRelation(ReadonlyEventInterface e1, ReadonlyEventInterface e2) {
+    boolean inRelation(ReadonlyEventInterface e1, ReadonlyEventInterface e2) {
         return relation[eventToGroupId.get(e1)][eventToGroupId.get(e2)];
     }
 
@@ -38,6 +37,8 @@ public class TransitiveClosure {
 
         private final Map<ReadonlyEventInterface, Integer> eventToGroupId;
 
+        private int groupCountSize = 0;
+
         private final List<Pair<ReadonlyEventInterface, ReadonlyEventInterface>> relations = new ArrayList<>();
 
         private Builder(int size) {
@@ -45,7 +46,8 @@ public class TransitiveClosure {
         }
 
         public void createNewGroup(ReadonlyEventInterface e) {
-            eventToGroupId.put(e, eventToGroupId.size());
+            eventToGroupId.put(e, groupCountSize);
+            groupCountSize++;
         }
 
         /**
@@ -60,7 +62,8 @@ public class TransitiveClosure {
         }
 
         public TransitiveClosure build() {
-            int numOfGroups = eventToGroupId.size();
+            int numOfGroups = groupCountSize;
+
             boolean[][] f = new boolean[numOfGroups][numOfGroups];
             relations.forEach(p ->
                     f[eventToGroupId.get(p.getLeft())][eventToGroupId.get(p.getRight())] = true);

--- a/java/src/main/java/com/runtimeverification/rvpredict/trace/producers/TraceProducers.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/trace/producers/TraceProducers.java
@@ -14,6 +14,7 @@ import com.runtimeverification.rvpredict.trace.producers.base.OtidToSignalDepthT
 import com.runtimeverification.rvpredict.trace.producers.base.RawTraces;
 import com.runtimeverification.rvpredict.trace.producers.base.RawTracesByTtid;
 import com.runtimeverification.rvpredict.trace.producers.base.SortedTtidsWithParentFirst;
+import com.runtimeverification.rvpredict.trace.producers.base.StackTraces;
 import com.runtimeverification.rvpredict.trace.producers.base.TtidToStartAndJoinEventsForWindow;
 import com.runtimeverification.rvpredict.trace.producers.base.ThreadInfosComponent;
 import com.runtimeverification.rvpredict.trace.producers.base.TtidSetDifference;
@@ -153,6 +154,11 @@ public class TraceProducers extends ProducerModule {
     public final ComputingProducerWrapper<TtidsToSignalEnabling> ttidsToSignalEnabling =
             new ComputingProducerWrapper<>(
                     new TtidsToSignalEnabling(signalMaskAtWindowStartWithInferences),
+                    this);
+
+    public final ComputingProducerWrapper<StackTraces> stackTraces =
+            new ComputingProducerWrapper<>(
+                    new StackTraces(rawTraces),
                     this);
 
     public void startWindow(

--- a/java/src/main/java/com/runtimeverification/rvpredict/trace/producers/base/StackTraces.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/trace/producers/base/StackTraces.java
@@ -1,0 +1,109 @@
+package com.runtimeverification.rvpredict.trace.producers.base;
+
+import com.google.common.collect.ImmutableList;
+import com.runtimeverification.rvpredict.algorithm.BinarySearch;
+import com.runtimeverification.rvpredict.log.EventType;
+import com.runtimeverification.rvpredict.log.ReadonlyEventInterface;
+import com.runtimeverification.rvpredict.producerframework.ComputingProducer;
+import com.runtimeverification.rvpredict.producerframework.ComputingProducerWrapper;
+import com.runtimeverification.rvpredict.producerframework.ProducerState;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class StackTraces extends ComputingProducer<StackTraces.State> {
+    private final RawTraces rawTraces;
+    public StackTraces(ComputingProducerWrapper<RawTraces> rawTraces) {
+        super(new State());
+        this.rawTraces = rawTraces.getAndRegister(this);
+    }
+
+    @Override
+    protected void compute() {
+        rawTraces.getTraces().forEach(rawTrace -> {
+            Deque<StackTraceAfterEvent> stackTrace = new ArrayDeque<>();
+            ImmutableList.Builder<StackTraceAfterEvent> stackTraces = ImmutableList.builder();
+            for (int i = 0; i < rawTrace.size(); i++) {
+                ReadonlyEventInterface e = rawTrace.event(i);
+                if (e.getType() == EventType.INVOKE_METHOD) {
+                    StackTraceAfterEvent stack =
+                            new StackTraceAfterEvent(
+                                    e, Optional.ofNullable(stackTrace.peekLast()));
+                    stackTrace.addLast(stack);
+                    stackTraces.add(stack);
+                } else if (e.getType() == EventType.FINISH_METHOD) {
+                    if (!stackTrace.isEmpty()) {
+                        stackTrace.removeLast();
+                    }
+                    stackTraces.add(new StackTraceAfterEvent(
+                            e, Optional.ofNullable(stackTrace.peekLast())));
+                }
+            }
+            getState().ttidToStackTrace.put(rawTrace.getThreadInfo().getId(), stackTraces.build());
+        });
+    }
+
+    public ImmutableList.Builder<ReadonlyEventInterface> getStackTraceAfterEventBuilder(int ttid, long eventId) {
+        return getStackTraceAfterEventInternal(ttid, eventId).map(
+                StackTraceAfterEvent::asListBuilder).orElse(ImmutableList.builder());
+    }
+
+    private Optional<StackTraceAfterEvent> getStackTraceAfterEventInternal(int ttid, long eventId) {
+        List<StackTraceAfterEvent> stacks = getState().ttidToStackTrace.get(ttid);
+        if (stacks == null) {
+            return Optional.empty();
+        }
+        OptionalInt maybeIndex = BinarySearch.getIndexLessOrEqual(stacks, StackTraceAfterEvent::getEventId, eventId);
+        if (!maybeIndex.isPresent()) {
+            return Optional.empty();
+        }
+        int index = maybeIndex.getAsInt();
+        return Optional.of(stacks.get(index));
+    }
+
+    private class StackTraceAfterEvent {
+        private final ReadonlyEventInterface event;
+        private final Optional<StackTraceAfterEvent> previousEvent;
+
+        private StackTraceAfterEvent(
+                ReadonlyEventInterface event,
+                Optional<StackTraceAfterEvent> previousEvent) {
+            this.event = event;
+            this.previousEvent = previousEvent;
+        }
+
+        private long getEventId() {
+            return event.getEventId();
+        }
+
+        private ImmutableList.Builder<ReadonlyEventInterface> asListBuilder() {
+            /*
+              if (previousEvent.isPresent()) {
+
+                  return previousEvent.get().asListBuilder().add(event);
+              }
+              return ImmutableList.<ReadonlyEventInterface>builder().add(event);
+            */
+            ImmutableList.Builder<ReadonlyEventInterface> parentBuilder =
+                    previousEvent.map(StackTraceAfterEvent::asListBuilder).orElse(ImmutableList.builder());
+            if (event.getType() == EventType.INVOKE_METHOD) {
+                return parentBuilder.add(event);
+            }
+            return parentBuilder;
+        }
+    }
+
+    protected static class State implements ProducerState {
+        Map<Integer, List<StackTraceAfterEvent>> ttidToStackTrace = new HashMap<>();
+
+        @Override
+        public void reset() {
+            ttidToStackTrace.clear();
+        }
+    }
+}


### PR DESCRIPTION
* O(n^2) stack checks in MaximalRaceDetector.computeUnknownRaceSuspects instead of O(n^3) - race.getRaceDataSig() was in O(event-count)

* Transitive closure is still O(n^3), but previously node numbers were assigned badly, which meant that almost all 'f' matrix entries were not representing any actual node, but were still used in the Roy-Floyd algorithm.