### PR TITLE
Install `atdgen` version 2 or greater, and use the utility called `at…

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -1,4 +1,4 @@
 .include <mkc.init.mk>
 
 all:
-	@atdj.opt -package com.runtimeverification.error.data $(ERROR_ATD)
+	@atdj -package com.runtimeverification.error.data $(ERROR_ATD)

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ yes n | opam init
 opam update 
 opam switch 4.03.0
 eval $(opam config env)
-OPAMYES=true opam install ocp-ocamlres ocamlbuild-atdgen csv uri atdgen atdj
+OPAMYES=true opam install ocp-ocamlres ocamlbuild-atdgen csv uri "atdgen>=2" atdj
 
 home_slash=${HOME}/
 bindir=${objdir}/.tools/bin


### PR DESCRIPTION
…dj`,

which is (I guess) the new name of the utility `atdj.opt`.

This fixes some issues that appear if, for example, you remove your `rv-predict/.opam/` directory and run `setup.sh` again.