### PR TITLE
Fix some `rvpa` tests that the new usage info broke.

### DIFF
--- a/ctests/forkfail/.gitignore
+++ b/ctests/forkfail/.gitignore
@@ -1,1 +1,2 @@
 forkfail
+hs_err_pid*.log

--- a/ctests/rvpa/toofew/expect.out
+++ b/ctests/rvpa/toofew/expect.out
@@ -1,3 +1,4 @@
 rvpa: too few arguments
 usage: rvpa [--window size] [--no-shorten|--no-symbol|--no-trim]
-    [--html-dir directory] [--] program [trace-file]
+    [--html-dir directory] [--interrupts-target number] [--]
+    program [trace-file]

--- a/ctests/rvpa/toomany/expect.out
+++ b/ctests/rvpa/toomany/expect.out
@@ -1,3 +1,4 @@
 rvpa: too many arguments
 usage: rvpa [--window size] [--no-shorten|--no-symbol|--no-trim]
-    [--html-dir directory] [--] program [trace-file]
+    [--html-dir directory] [--interrupts-target number] [--]
+    program [trace-file]

--- a/ctests/trace/gnutest_sig/.gitignore
+++ b/ctests/trace/gnutest_sig/.gitignore
@@ -1,0 +1,1 @@
+gnutest_sig

--- a/ctests/trace/gnutest_sig/expect.out
+++ b/ctests/trace/gnutest_sig/expect.out
@@ -2,14 +2,14 @@ tid 1.0 {} begin thread
 tid 1.0 in main at .../gnutest_sig/gnutest_sig.c:99 enter function cfa . return {}
 tid 1.0 in main at .../gnutest_sig/gnutest_sig.c:106 establish signal action signal 6 handler in handler at .../gnutest_sig/gnutest_sig.c:70 mask #4
 tid 1.1 {} enter signal handler signal 6 handler in handler at .../gnutest_sig/gnutest_sig.c:70
-tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 enter function cfa . return {}
+tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 enter function cfa . return in __rvpredict_handler_wrapper at .../ngrt/rvpsignal.c:376:6
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:78 load 4 00000000 <- entry_count at gnutest_sig.c;handler
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:78 store 4 0x00000001 -> entry_count at gnutest_sig.c;handler
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 exit function
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 exit signal handler
 tid 1.0 in main at .../gnutest_sig/gnutest_sig.c:110 establish signal action signal 6 handler in handler at .../gnutest_sig/gnutest_sig.c:70 mask #3
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 enter signal handler signal 6 handler in handler at .../gnutest_sig/gnutest_sig.c:70
-tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 enter function cfa . return {}
+tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 enter function cfa . return in __rvpredict_handler_wrapper at .../ngrt/rvpsignal.c:376:6
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:78 load 4 0x00000001 <- entry_count at gnutest_sig.c;handler
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:78 store 4 0x00000002 -> entry_count at gnutest_sig.c;handler
 tid 1.1 in handler at .../gnutest_sig/gnutest_sig.c:70 exit function


### PR DESCRIPTION
Fix `gnutest_sig`, which our improved symbolizable `rvpdump` output
seems to have broken.

Ignore more build products while I'm here.