### PR TITLE
A bunch of changes to appease `gcc`:

### DIFF
--- a/ctests/stats/on_signal/Makefile
+++ b/ctests/stats/on_signal/Makefile
@@ -5,6 +5,7 @@ MKINSTALL=no
 PATH:=$(.OBJDIR)/../../toolset/bin:$(PATH)
 .export PATH
 CC?=rvpc
+LDFLAGS+=-pthread	# needed if CC is overridden with clang or gcc
 PROG=on_signal
 WARNS=5
 CPPFLAGS+=-I$(.CURDIR)/../../../include

--- a/ctests/trace/atomic_load/atomic_load.c
+++ b/ctests/trace/atomic_load/atomic_load.c
@@ -25,16 +25,15 @@ main(void)
 	uint32_t u32 = initial_u32;
 	uint64_t u64 = initial_u64;
 
-	uint8_t  lcl_u8;
-	uint16_t lcl_u16;
-	uint32_t lcl_u32;
-	uint64_t lcl_u64;
+	uint8_t  lcl_u8 __unused;
+	uint16_t lcl_u16 __unused;
+	uint32_t lcl_u32 __unused;
+	uint64_t lcl_u64 __unused;
 
 	lcl_u8  = u8;
 	lcl_u16 = u16;
 	lcl_u32 = u32;
 	lcl_u64 = u64;
-
 
 	return EXIT_SUCCESS;
 }

--- a/ctests/trace/atomic_store/atomic_store.c
+++ b/ctests/trace/atomic_store/atomic_store.c
@@ -9,10 +9,10 @@
 #include <stdlib.h>
 #include "nbcompat.h"
 
-static const uint8_t  initial_u8 = 0x39;
-static const uint16_t initial_u16 = 0x40;
-static const uint32_t initial_u32 = 0x41;
-static const uint64_t initial_u64 = 0x43;
+#define  initial_u8 0x39
+#define initial_u16 0x40
+#define initial_u32 0x41
+#define initial_u64 0x43
 
 static const uint8_t  end_u8 = 0x10;
 static const uint16_t end_u16 = 0x1000;
@@ -39,10 +39,10 @@ main(void)
 	uint32_t u32 = initial_u32;
 	uint64_t u64 = initial_u64;
 
-	uint8_t  lcl_u8;
-	uint16_t lcl_u16;
-	uint32_t lcl_u32;
-	uint64_t lcl_u64;
+	uint8_t  lcl_u8 __unused;
+	uint16_t lcl_u16 __unused;
+	uint32_t lcl_u32 __unused;
+	uint64_t lcl_u64 __unused;
 
 	lcl_u8  = u8;
 	lcl_u16 = u16;

--- a/ctests/trace/limits/G/G.c
+++ b/ctests/trace/limits/G/G.c
@@ -1,9 +1,11 @@
 #include <stdlib.h>
 
+#include "nbcompat.h"
+
 int
 main(void)
 {
-	volatile int x;
+	volatile int x __unused;
 	int i;
 
 	for (i = 0; i < 1000000000; i++)

--- a/ctests/trace/limits/M/M.c
+++ b/ctests/trace/limits/M/M.c
@@ -1,9 +1,11 @@
 #include <stdlib.h>
 
+#include "nbcompat.h"
+
 int
 main(void)
 {
-	volatile int x;
+	volatile int x __unused;
 	int i;
 
 	for (i = 0; i < 1000000; i++)

--- a/ctests/trace/limits/k/k.c
+++ b/ctests/trace/limits/k/k.c
@@ -1,9 +1,11 @@
 #include <stdlib.h>
 
+#include "nbcompat.h"
+
 int
 main(void)
 {
-	volatile int x;
+	volatile int x __unused;
 	int i;
 
 	for (i = 0; i < 1000; i++)

--- a/ctests/trace/limits/negative/negative.c
+++ b/ctests/trace/limits/negative/negative.c
@@ -1,9 +1,11 @@
 #include <stdlib.h>
 
+#include "nbcompat.h"
+
 int
 main(void)
 {
-	volatile int x;
+	volatile int x __unused;
 
 	x = 999;
 

--- a/ctests/trace/natest/natest.c
+++ b/ctests/trace/natest/natest.c
@@ -9,10 +9,10 @@
 #include <stdlib.h>
 #include "nbcompat.h"
 
-static const uint8_t  initial_u8 = 0x39;
-static const uint16_t initial_u16 = 0x40;
-static const uint32_t initial_u32 = 0x41;
-static const uint64_t initial_u64 = 0x43;
+#define initial_u8	0x39
+#define initial_u16	0x40
+#define initial_u32	0x41
+#define initial_u64	0x43
 
 static const uint8_t  end_u8 = 0x10;
 static const uint16_t end_u16 = 0x1000;
@@ -39,10 +39,10 @@ main(void)
 	uint32_t u32 = initial_u32;
 	uint64_t u64 = initial_u64;
 
-	uint8_t  lcl_u8;
-	uint16_t lcl_u16;
-	uint32_t lcl_u32;
-	uint64_t lcl_u64;
+	uint8_t  lcl_u8 __unused;
+	uint16_t lcl_u16 __unused;
+	uint32_t lcl_u32 __unused;
+	uint64_t lcl_u64 __unused;
 
 	lcl_u8  = u8;
 	lcl_u16 = u16;

--- a/ctests/trace/store/store.c
+++ b/ctests/trace/store/store.c
@@ -4,6 +4,7 @@
 #include <stdint.h>	/* for uint8_t, uint32_t */
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "nbcompat.h"
 
 static const uint8_t initial_u8 = 0x39;
@@ -19,10 +20,10 @@ static const uint64_t end_u64 = (uint64_t)0xf << 32;
 int
 main(void)
 {
-	volatile _Atomic uint8_t u8 = initial_u8;
-	volatile _Atomic uint16_t u16 = initial_u16;
-	volatile _Atomic uint32_t u32 = initial_u32;
-	volatile _Atomic uint64_t u64 = initial_u64;
+	volatile _Atomic uint8_t u8 __unused = initial_u8;
+	volatile _Atomic uint16_t u16 __unused = initial_u16;
+	volatile _Atomic uint32_t u32 __unused = initial_u32;
+	volatile _Atomic uint64_t u64 __unused = initial_u64;
 
 	u8 = end_u8;
 	/* In `expect.out`, the next store is ascribed to the previous line

--- a/ctests/trace/xchange_test/xchange_test.c
+++ b/ctests/trace/xchange_test/xchange_test.c
@@ -34,10 +34,10 @@ main(void)
 	uint32_t u32 = initial_u32;
 	uint64_t u64 = initial_u64;
 
-	uint8_t  lcl_u8;
-	uint16_t lcl_u16;
-	uint32_t lcl_u32;
-	uint64_t lcl_u64;
+	uint8_t  lcl_u8 __unused;
+	uint16_t lcl_u16 __unused;
+	uint32_t lcl_u32 __unused;
+	uint64_t lcl_u64 __unused;
 
 	lcl_u8  = u8;
 	lcl_u16 = u16;

--- a/llvm/ngrt/Makefile
+++ b/llvm/ngrt/Makefile
@@ -16,10 +16,9 @@ INCS=rvpredict_intr.h
 CC?=clang
 CFLAGS+=-std=c11
 CFLAGS+=-pedantic
-CFLAGS+=-Wmissing-prototypes
 #COPTS+=-O3
 COPTS+=-g
-CFLAGS+=-Wmissing-prototypes
+CFLAGS+=-Wall -Wmissing-prototypes
 CPPFLAGS+=-I$(.CURDIR)/../../include
 CPPFLAGS+=-D_GNU_SOURCE	# for <dlfcn.h> constant RTLD_NEXT
 SRCS+=access.c const.c deltops.c func.c lock.c notimpl.c

--- a/llvm/ngrt/const.c
+++ b/llvm/ngrt/const.c
@@ -1,4 +1,5 @@
 #include <stdatomic.h>
+#include <stdint.h>
 
 const int32_t __rvpredict_memory_order_relaxed = memory_order_relaxed;
 const int32_t __rvpredict_memory_order_acquire = memory_order_acquire;

--- a/llvm/ngrt/interpose.h
+++ b/llvm/ngrt/interpose.h
@@ -35,7 +35,7 @@ __rettype __func(__VA_ARGS__) __attribute__((weak,			\
 				     visibility("default")))
 
 #define	ESTABLISH_PTR_TO_REAL(__fntype, __fn)	do {		\
-	real_##__fn = (__fntype)dlsym(RTLD_NEXT, #__fn);	\
+	real_##__fn = (__fntype)(uintptr_t)dlsym(RTLD_NEXT, #__fn);	\
 } while (/*CONSTCOND*/false)
 
 INTERPOSE_DECLS(int, pthread_join, pthread_t, void **);

--- a/llvm/ngrt/intr.c
+++ b/llvm/ngrt/intr.c
@@ -164,12 +164,12 @@ __rvpredict_intr_register(void (*handler)(void), int32_t prio)
 {
 	if (rvp_static_intr_debug) {
 		fprintf(stderr, "%s: handler %p prio %" PRId32 "\n",
-		    __func__, (const void *)handler, prio);
+		    __func__, (const void *)(uintptr_t)handler, prio);
 	}
 	if (rvp_static_nintrs >= __arraycount(rvp_static_intr)) {
 		errx(EXIT_FAILURE,
 		    "%s: no room for handler %p prio %" PRId32 "\n",
-		    __func__, (const void *)handler, prio);
+		    __func__, (const void *)(uintptr_t)handler, prio);
 	}
 	rvp_static_intr[rvp_static_nintrs++] =
 	    (rvp_static_intr_t){.si_handler = handler, .si_prio = prio,

--- a/llvm/ngrt/ring.h
+++ b/llvm/ngrt/ring.h
@@ -4,6 +4,7 @@
 #define _RVP_RING_H_
 
 #include <sched.h>
+#include <signal.h>	/* for sigset_t */
 #include <stdatomic.h>	/* for atomic_store_explicit */
 #include <stdbool.h>
 #include <stdint.h>	/* for uint32_t */

--- a/llvm/ngrt/rvpsignal.c
+++ b/llvm/ngrt/rvpsignal.c
@@ -269,7 +269,7 @@ rvp_signal_rings_replenish(void)
 	}
 
 	for (nallocated = nclean; nallocated <= nneeded; nallocated++) {
-		rvp_ring_t *r = calloc(sizeof(*r), 1);
+		r = calloc(sizeof(*r), 1);
 		if (r == NULL && nallocated == 0)
 			err(EXIT_FAILURE, "%s: calloc", __func__);
 		else if (r == NULL)
@@ -362,8 +362,8 @@ __rvpredict_handler_wrapper(int signum, siginfo_t *info, void *ctx)
 	rvp_buf_put_voidptr(&b, rvp_vec_and_op_to_deltop(0, RVP_OP_ENTERSIG));
 	rvp_buf_put_voidptr(&b,
 	    (s->s_handler != NULL)
-	        ? (const void *)s->s_handler
-		: (const void *)s->s_sigaction);
+	        ? (const void *)(uintptr_t)s->s_handler
+		: (const void *)(uintptr_t)s->s_sigaction);
 	rvp_buf_put_u64(&b, r->r_lgen);
 	rvp_buf_put(&b, signum);
 	rvp_ring_put_buf(r, b);
@@ -676,19 +676,6 @@ rvp_thread_trace_getmask(rvp_thread_t *t __unused,
 	bs = intern_sigset(mask_to_sigset(omask, &set));
 	rvp_trace_mask(RVP_OP_SIGGETMASK, bs->bs_number, retaddr);
 }
-
-#if 0
-static inline void
-trace_sigmask_op(const void *retaddr, int how)
-{
-	rvp_ring_t *r = rvp_ring_for_curthr();
-	rvp_buf_t b = RVP_BUF_INITIALIZER;
-	rvp_buf_put_pc_and_op(&b, &r->r_lastpc, retaddr, op);
-	rvp_buf_put_voidptr(&b, mtx);
-
-	rvp_ring_put_buf(r, b);
-}
-#endif
 
 static int
 rvp_change_sigmask(rvp_change_sigmask_t changefn, const void *retaddr, int how,

--- a/llvm/ngrt/serialize.c
+++ b/llvm/ngrt/serialize.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <err.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/llvm/ngrt/supervise.c
+++ b/llvm/ngrt/supervise.c
@@ -295,7 +295,8 @@ rvp_online_analysis_start(void)
 	analysis_pid = fork();
 
 	if (analysis_pid == 0) {
-		char *const args[] = {"rvpa", binpath, "/dev/stdin", NULL};
+		char cmdname[] = "rvpa", tracename[] = "/dev/stdin";
+		char *const args[] = {cmdname, binpath, tracename, NULL};
 
 		/* We move the analyzer into its own process group
 		 * so that signals generated on the terminal (e.g.,
@@ -565,7 +566,8 @@ rvp_supervision_start(void)
 	}
 
 	if (pid == 0) {
-		char *const args[] = {"rvpa", binpath, NULL};
+		char cmdname[] = "rvpa";
+		char *const args[] = {cmdname, binpath, NULL};
 
 		if (chdir(tmpdir) == -1) {
 			err(EXIT_FAILURE, "%s could not change to "

--- a/llvm/sigsim/sigsim.mk
+++ b/llvm/sigsim/sigsim.mk
@@ -3,6 +3,9 @@ LIB?=rvpsigsim_$(SIGSIM)
 .PATH: $(.CURDIR)/../../ngrt
 
 CC?=clang
+.if $(CC) == gcc
+CPPFLAGS+=-U_FORTIFY_SOURCE
+.endif
 CFLAGS+=-std=c11
 CFLAGS+=-pedantic
 CFLAGS+=-Wmissing-prototypes

--- a/unit_ctests/serialization/empty_ring/Makefile
+++ b/unit_ctests/serialization/empty_ring/Makefile
@@ -1,5 +1,6 @@
 PROG=empty_ring
 
+CFLAGS+=-std=c11 -D_POSIX_SOURCE -D_BSD_SOURCE
 .include "../serialization.mk"
 .include "../test.mk"
 

--- a/unit_ctests/serialization/empty_ring/main.c
+++ b/unit_ctests/serialization/empty_ring/main.c
@@ -8,8 +8,8 @@
 
 #include "ring.h"
 
-const uint32_t tid = 0xdeadbeef;
-const uint32_t idepth = 7;
+static const uint32_t tid = 0xdeadbeef;
+static const uint32_t idepth = 7;
 uint32_t items[5];
 
 rvp_ring_stats_t rs = {
@@ -18,45 +18,45 @@ rvp_ring_stats_t rs = {
 	, .rs_iring_spins = 0
 };
 
-rvp_ring_t r = {
-	  .r_last = &items[__arraycount(items) - 1]
-	, .r_items = items
-	, .r_consumer = &items[__arraycount(items) - 2]
-	, .r_producer = &items[__arraycount(items) - 2]
-	, .r_lastpc = NULL	// expected to be unused
-	, .r_lgen = 0		// expected to be unused
-	, .r_next = NULL	// expected to be unused
-	// clean: no sequence is using this ring, and it has no
-	// items that need to be serialized
-	//
-	// dirty: no sequence is using this ring, however, it
-	// contains items that need to be serialized
-	//
-	// in-use: a sequence is logging on this ring; it
-	// may or may not contains items that need to be serialized
-	, .r_state = RVP_RING_S_DIRTY
-	, .r_tid = tid
-	, .r_idepth = idepth
-	, .r_iring = {
-		  .ir_producer = &r.r_iring.ir_items[0]
-		, .ir_consumer = &r.r_iring.ir_items[0]
-		, .ir_items = {{
-			  .it_interruptor = NULL
-			, .it_interrupted_idx = 0
-			, .it_interruptor_sidx = 0
-			, .it_interruptor_eidx = 0
-		  }}
-	  }
-	, .r_sigdepth = {
-		  .deltop = 0
-		, .depth = 0
-	  }
-	, .r_stats = &rs
-};
-
 int
 main(void)
 {
+	rvp_ring_t r = {
+		  .r_last = &items[__arraycount(items) - 1]
+		, .r_items = items
+		, .r_consumer = &items[__arraycount(items) - 2]
+		, .r_producer = &items[__arraycount(items) - 2]
+		, .r_lastpc = NULL	// expected to be unused
+		, .r_lgen = 0		// expected to be unused
+		, .r_next = NULL	// expected to be unused
+		// clean: no sequence is using this ring, and it has no
+		// items that need to be serialized
+		//
+		// dirty: no sequence is using this ring, however, it
+		// contains items that need to be serialized
+		//
+		// in-use: a sequence is logging on this ring; it
+		// may or may not contains items that need to be serialized
+		, .r_state = RVP_RING_S_DIRTY
+		, .r_tid = tid
+		, .r_idepth = idepth
+		, .r_iring = {
+			  .ir_producer = &r.r_iring.ir_items[0]
+			, .ir_consumer = &r.r_iring.ir_items[0]
+			, .ir_items = {{
+				  .it_interruptor = NULL
+				, .it_interrupted_idx = 0
+				, .it_interruptor_sidx = 0
+				, .it_interruptor_eidx = 0
+			  }}
+		  }
+		, .r_sigdepth = {
+			  .deltop = 0
+			, .depth = 0
+		  }
+		, .r_stats = &rs
+	};
+
 	rvp_lastctx_t lc = (rvp_lastctx_t){
 		  .lc_tid = tid
 		, .lc_idepth = idepth

--- a/unit_ctests/serialization/full_ring/main.c
+++ b/unit_ctests/serialization/full_ring/main.c
@@ -18,45 +18,44 @@ rvp_ring_stats_t rs = {
 	, .rs_iring_spins = 0
 };
 
-rvp_ring_t r = {
-	  .r_last = &items[__arraycount(items) - 1]
-	, .r_items = items
-	, .r_consumer = &items[__arraycount(items) - 2]
-	, .r_producer = &items[__arraycount(items) - 3]
-	, .r_lastpc = NULL	// expected to be unused
-	, .r_lgen = 0		// expected to be unused
-	, .r_next = NULL	// expected to be unused
-	// clean: no sequence is using this ring, and it has no
-	// items that need to be serialized
-	//
-	// dirty: no sequence is using this ring, however, it
-	// contains items that need to be serialized
-	//
-	// in-use: a sequence is logging on this ring; it
-	// may or may not contains items that need to be serialized
-	, .r_state = RVP_RING_S_DIRTY
-	, .r_tid = tid
-	, .r_idepth = idepth
-	, .r_iring = {
-		  .ir_producer = &r.r_iring.ir_items[0]
-		, .ir_consumer = &r.r_iring.ir_items[0]
-		, .ir_items = {{
-			  .it_interruptor = NULL
-			, .it_interrupted_idx = 0
-			, .it_interruptor_sidx = 0
-			, .it_interruptor_eidx = 0
-		  }}
-	  }
-	, .r_sigdepth = {
-		  .deltop = 0
-		, .depth = 0
-	  }
-	, .r_stats = &rs
-};
-
 int
 main(void)
 {
+	rvp_ring_t r = {
+		  .r_last = &items[__arraycount(items) - 1]
+		, .r_items = items
+		, .r_consumer = &items[__arraycount(items) - 2]
+		, .r_producer = &items[__arraycount(items) - 3]
+		, .r_lastpc = NULL	// expected to be unused
+		, .r_lgen = 0		// expected to be unused
+		, .r_next = NULL	// expected to be unused
+		// clean: no sequence is using this ring, and it has no
+		// items that need to be serialized
+		//
+		// dirty: no sequence is using this ring, however, it
+		// contains items that need to be serialized
+		//
+		// in-use: a sequence is logging on this ring; it
+		// may or may not contains items that need to be serialized
+		, .r_state = RVP_RING_S_DIRTY
+		, .r_tid = tid
+		, .r_idepth = idepth
+		, .r_iring = {
+			  .ir_producer = &r.r_iring.ir_items[0]
+			, .ir_consumer = &r.r_iring.ir_items[0]
+			, .ir_items = {{
+				  .it_interruptor = NULL
+				, .it_interrupted_idx = 0
+				, .it_interruptor_sidx = 0
+				, .it_interruptor_eidx = 0
+			  }}
+		  }
+		, .r_sigdepth = {
+			  .deltop = 0
+			, .depth = 0
+		  }
+		, .r_stats = &rs
+	};
 	rvp_lastctx_t lc = (rvp_lastctx_t){
 		  .lc_tid = tid
 		, .lc_idepth = idepth

--- a/unit_ctests/serialization/initial_intr/main.c
+++ b/unit_ctests/serialization/initial_intr/main.c
@@ -24,81 +24,81 @@ rvp_ring_stats_t rs = {
 	, .rs_iring_spins = 0
 };
 
-rvp_ring_t intr = {
-	  .r_last = &intr_items[__arraycount(intr_items) - 1]
-	, .r_items = intr_items
-	, .r_consumer = &intr_items[__arraycount(intr_items) - 3]
-	, .r_producer = &intr_items[__arraycount(intr_items) - 2]
-	, .r_lastpc = NULL	// expected to be unused
-	, .r_lgen = 0		// expected to be unused
-	, .r_next = NULL	// expected to be unused
-	// clean: no sequence is using this ring, and it has no
-	// items that need to be serialized
-	//
-	// dirty: no sequence is using this ring, however, it
-	// contains items that need to be serialized
-	//
-	// in-use: a sequence is logging on this ring; it
-	// may or may not contains items that need to be serialized
-	, .r_state = RVP_RING_S_DIRTY
-	, .r_tid = tid
-	, .r_idepth = idepth + 1
-	, .r_iring = {
-		  .ir_producer = &intr.r_iring.ir_items[0]
-		, .ir_consumer = &intr.r_iring.ir_items[0]
-		, .ir_items = {{
-			  .it_interruptor = NULL
-			, .it_interrupted_idx = 0
-			, .it_interruptor_sidx = 0
-			, .it_interruptor_eidx = 0
-		  }}
-	  }
-	, .r_sigdepth = {
-		  .deltop = 0
-		, .depth = idepth + 1
-	  }
-	, .r_stats = &rs
-};
-
-rvp_ring_t r = {
-	  .r_last = &items[__arraycount(items) - 1]
-	, .r_items = items
-	, .r_consumer = &items[__arraycount(items) - 2]
-	, .r_producer = &items[__arraycount(items) - 2]
-	, .r_lastpc = NULL	// expected to be unused
-	, .r_lgen = 0		// expected to be unused
-	, .r_next = NULL	// expected to be unused
-	// clean: no sequence is using this ring, and it has no
-	// items that need to be serialized
-	//
-	// dirty: no sequence is using this ring, however, it
-	// contains items that need to be serialized
-	//
-	// in-use: a sequence is logging on this ring; it
-	// may or may not contains items that need to be serialized
-	, .r_state = RVP_RING_S_DIRTY
-	, .r_tid = tid
-	, .r_idepth = idepth
-	, .r_iring = {
-		  .ir_consumer = &r.r_iring.ir_items[0]
-		, .ir_producer = &r.r_iring.ir_items[1]
-		, .ir_items = {{
-			  .it_interruptor = &intr
-			, .it_interrupted_idx = __arraycount(items) - 2
-			, .it_interruptor_sidx = __arraycount(intr_items) - 3
-			, .it_interruptor_eidx = __arraycount(intr_items) - 2
-		  }}
-	  }
-	, .r_sigdepth = {
-		  .deltop = 0
-		, .depth = idepth
-	  }
-	, .r_stats = &intr_rs
-};
-
 int
 main(void)
 {
+	rvp_ring_t intr = {
+		  .r_last = &intr_items[__arraycount(intr_items) - 1]
+		, .r_items = intr_items
+		, .r_consumer = &intr_items[__arraycount(intr_items) - 3]
+		, .r_producer = &intr_items[__arraycount(intr_items) - 2]
+		, .r_lastpc = NULL	// expected to be unused
+		, .r_lgen = 0		// expected to be unused
+		, .r_next = NULL	// expected to be unused
+		// clean: no sequence is using this ring, and it has no
+		// items that need to be serialized
+		//
+		// dirty: no sequence is using this ring, however, it
+		// contains items that need to be serialized
+		//
+		// in-use: a sequence is logging on this ring; it
+		// may or may not contains items that need to be serialized
+		, .r_state = RVP_RING_S_DIRTY
+		, .r_tid = tid
+		, .r_idepth = idepth + 1
+		, .r_iring = {
+			  .ir_producer = &intr.r_iring.ir_items[0]
+			, .ir_consumer = &intr.r_iring.ir_items[0]
+			, .ir_items = {{
+				  .it_interruptor = NULL
+				, .it_interrupted_idx = 0
+				, .it_interruptor_sidx = 0
+				, .it_interruptor_eidx = 0
+			  }}
+		  }
+		, .r_sigdepth = {
+			  .deltop = 0
+			, .depth = idepth + 1
+		  }
+		, .r_stats = &rs
+	};
+
+	rvp_ring_t r = {
+		  .r_last = &items[__arraycount(items) - 1]
+		, .r_items = items
+		, .r_consumer = &items[__arraycount(items) - 2]
+		, .r_producer = &items[__arraycount(items) - 2]
+		, .r_lastpc = NULL	// expected to be unused
+		, .r_lgen = 0		// expected to be unused
+		, .r_next = NULL	// expected to be unused
+		// clean: no sequence is using this ring, and it has no
+		// items that need to be serialized
+		//
+		// dirty: no sequence is using this ring, however, it
+		// contains items that need to be serialized
+		//
+		// in-use: a sequence is logging on this ring; it
+		// may or may not contains items that need to be serialized
+		, .r_state = RVP_RING_S_DIRTY
+		, .r_tid = tid
+		, .r_idepth = idepth
+		, .r_iring = {
+			  .ir_consumer = &r.r_iring.ir_items[0]
+			, .ir_producer = &r.r_iring.ir_items[1]
+			, .ir_items = {{
+				  .it_interruptor = &intr
+				, .it_interrupted_idx = __arraycount(items) - 2
+				, .it_interruptor_sidx = __arraycount(intr_items) - 3
+				, .it_interruptor_eidx = __arraycount(intr_items) - 2
+			  }}
+		  }
+		, .r_sigdepth = {
+			  .deltop = 0
+			, .depth = idepth
+		  }
+		, .r_stats = &intr_rs
+	};
+
 	rvp_lastctx_t lc = (rvp_lastctx_t){
 		  .lc_tid = tid
 		, .lc_idepth = idepth

--- a/unit_ctests/serialization/test_opinit.c
+++ b/unit_ctests/serialization/test_opinit.c
@@ -1,4 +1,5 @@
 #include "nbcompat.h"
+#include "init.h"
 #include "trace.h"
 
 rvp_jumpless_op_t rvp_jumpless_op;


### PR DESCRIPTION
Remove some dead code and extraneous whitespace.

Rewrite some code that wasn't C-standard compliant.

Delete some unused variables.  Mark other actually-used "unused" variables
`__unused` to quite `gcc`.

Repair some code in `rvsyms` that used an uninitialized variable.
This probably caused our symbolization to foul up, sometimes!

Add some #includes to get missing prototypes.