### PR TITLE
Fix stack traces for interrupted threads/signals.

### DIFF
--- a/java/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEvent.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEvent.java
@@ -85,6 +85,16 @@ public abstract class ReadonlyEvent implements ReadonlyEventInterface {
     }
 
     @Override
+    public boolean isSignalLockEvent() {
+        return isLock() && (getLockRepresentation().getLockType() == LockRepresentation.LockType.SIGNAL_LOCK);
+    }
+
+    @Override
+    public boolean isSignalUnlockEvent() {
+        return isUnlock() && (getLockRepresentation().getLockType() == LockRepresentation.LockType.SIGNAL_LOCK);
+    }
+
+    @Override
     public boolean isSignalMaskRead() {
         return getType() == EventType.READ_WRITE_SIGNAL_MASK
                 || getType() == EventType.READ_SIGNAL_MASK;

--- a/java/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEventInterface.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/log/ReadonlyEventInterface.java
@@ -85,6 +85,8 @@ public interface ReadonlyEventInterface extends Comparable<ReadonlyEventInterfac
     boolean isCallStackEvent();
     boolean isInvokeMethod();
     boolean isSignalEvent();
+    boolean isSignalLockEvent();
+    boolean isSignalUnlockEvent();
     long getLockId();
     boolean isSimilarTo(ReadonlyEventInterface event);
     boolean isSignalMaskRead();

--- a/java/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
+++ b/java/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java
@@ -421,7 +421,7 @@ public class Trace {
         RawTrace t = maybeT.get();
         for (int i = 0; i < t.size(); i++) {
             ReadonlyEventInterface e = t.event(i);
-            if (e.getEventId() >= event.getEventId()) break;
+            if (e.getEventId() > event.getEventId()) break;
             if (e.isLock() && !e.isWaitAcq()) {
                 lockIdToLockState.computeIfAbsent(e.getLockId(), LockState::new)
                         .acquire(e);


### PR DESCRIPTION
The most important change is the one in java/src/main/java/com/runtimeverification/rvpredict/trace/Trace.java and I could have made a pull request containing only that.

However, the fix in java/src/main/java/com/runtimeverification/rvpredict/signals/EventsEnabledForSignalIterator.java makes sure that signal locks can't occur in traces in some rare cases when the interruption point is not computed properly, so I guess it's worth including it.