### PR TITLE
Document `--max-interrupt-depth depth` option in the manual page and

### DIFF
--- a/scripts/rvpa.1
+++ b/scripts/rvpa.1
@@ -13,9 +13,9 @@ instrumentation using
 .Op Fl n
 .Op Fl Fl help
 .Op Fl Fl window Ar size
-.Op Fl Fl window Ns = Ns Ar size
 .Op Fl Fl html-dir Ar directory
-.Op Fl Fl html-dir Ns = Ns Ar directory
+.Op Fl Fl interrupts-target Ar number
+.Op Fl Fl max-interrupt-depth Ar depth 
 .Op Fl Fl no-shorten
 .Op Fl Fl no-symbol
 .Op Fl Fl no-system
@@ -70,6 +70,21 @@ parameter overrides all previous
 and
 .Fl Fl output
 parameters on the command line.
+.It Fl Fl max-interrupt-depth Ar depth | Fl Fl max-interrupt-depth Ns = Ns Ar depth
+In each trace window, look for schedules where interrupts
+.Dq stack
+no more than
+.Ar depth
+deep, or no deeper than the trace events in that window actually show,
+whichever is deeper.
+A
+.Ar depth
+of 0 means no maximum.
+A
+.Ar depth
+of 1 means an interruption of a thread, a
+.Ar depth
+of 2 means an interruption of an interruption of a thread, and so on.
 .It Fl Fl interrupts-target Ar number | Fl Fl interrupt-target Ar number
 .It Fl Fl interrupts-target Ns = Ns Ar number | Fl Fl interrupt-target Ns = Ns Ar number 
 If there are fewer than

--- a/scripts/rvpa.sh
+++ b/scripts/rvpa.sh
@@ -13,7 +13,8 @@ _usage()
 {
 	cat 1>&2 <<EOF
 usage: $(basename $0) [--window size] [--no-shorten|--no-symbol|--no-trim]
-    [--html-dir directory] [--interrupts-target number] [--]
+    [--html-dir directory] [--interrupts-target number]
+    [--max-interrupt-depth number] [--]
     program [trace-file]
 EOF
 }
@@ -138,8 +139,8 @@ while [ $# -ge 1 ]; do
 		esac
 		;;
 	--interrupt-target=*|--interrupts-target=*)
-		eval interrupts_target=${1##--interrupt-target=}
-		eval interrupts_target=${interrupts_target##--interrupts-target=}
+		interrupts_target=${1##--interrupt-target=}
+		interrupts_target=${interrupts_target##--interrupts-target=}
 		shift
 		;;
 	--interrupt-target|--interrupts-target)
@@ -153,7 +154,7 @@ while [ $# -ge 1 ]; do
 		shift
 		;;
 	--window=*)
-		eval window="--window ${1##--window=}"
+		window="--window ${1##--window=}"
 		shift
 		;;
 	--window)
@@ -162,6 +163,15 @@ while [ $# -ge 1 ]; do
 		shift
 		;;
 	--global-timeout|--solver-timeout|--window-timeout)
+		analyze_passthrough="${analyze_passthrough:-} $1 $2"
+		shift
+		shift
+		;;
+	--max-interrupt-depth=*)
+		analyze_passthrough="${analyze_passthrough:-} --max-interrupt-depth ${1##--max-interrupt-depth=}"
+		shift
+		;;
+	--max-interrupt-depth)
 		analyze_passthrough="${analyze_passthrough:-} $1 $2"
 		shift
 		shift


### PR DESCRIPTION
usage.  Slightly simplify.  Pass `--max-interrupt-depth depth` through
`rvpa` to the analysis backend.

@virgil-serbanuta, I'm curious if I'm describing how the option works correctly in the manual. Let me know.