### PR TITLE
Use a priority for Predict's custom ctor.

### DIFF
--- a/llvm/pass/RVPredictInstrumentation.cpp
+++ b/llvm/pass/RVPredictInstrumentation.cpp
@@ -83,6 +83,7 @@ STATISTIC(NumOmittedReadsFromConstantGlobals,
 STATISTIC(NumOmittedReadsFromVtable, "Number of vtable reads");
 STATISTIC(NumOmittedNonCaptured, "Number of accesses ignored due to capturing");
 
+static const uint64_t kRVPCtorAndDtorPriority = 2;
 static const char *const kRVPredictModuleCtorName = "rvpredict.module_ctor";
 static const char *const kRVPredictInitName = "__rvpredict_init";
 
@@ -374,7 +375,7 @@ bool RVPredictInstrument::doInitialization(Module &M) {
   order_acq_rel->setAlignment(4);
   order_seq_cst->setAlignment(4);
 
-  appendToGlobalCtors(M, ctorfn, 0);
+  appendToGlobalCtors(M, ctorfn, kRVPCtorAndDtorPriority);
 
   return true;
 }


### PR DESCRIPTION
Ctors with priority run before ones without priority, and ones
with low priority run before ones with high priority. 1-100 are
reserved (and attempting to use them results in warnings),
so no regular programs should use it.

This should guarantee our ctor runs before regular program code.

Candidate fix for #990, but I don't know for sure if it fixes the problem.
(I'm trying p11-kit's testsuite, but it's showing unrelated problems, too)