### PR TITLE
Fix rv-html-report directory creation bug

### DIFF
--- a/errors/html-report/rv-html-report
+++ b/errors/html-report/rv-html-report
@@ -7,6 +7,7 @@ import uuid
 import argparse
 import os
 import urllib
+import errno
 
 from jinja2 import Environment, FileSystemLoader
 from pygments import highlight
@@ -204,8 +205,11 @@ def render_code(rel, abs, path, errors, to_js):
     if to_js:
         extension = ".js"
 
-    if not os.path.exists(args.output + '/' + directory):
+    try:
         os.makedirs(args.output + '/' + directory)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise
     if not os.path.exists(filename):
         return
     with open(filename, 'r') as f, open(args.output + '/' + path + extension, 'w') as target:

--- a/errors/html-report/static/style.css
+++ b/errors/html-report/static/style.css
@@ -94,6 +94,7 @@ table#myTable {
 }
 table#myTable.no-footer {
   padding-bottom: 0;
+  margin-bottom: 46px;
 }
 table.dataTable thead .sorting {
     background-image: url("./images/sort_both.png") !important;
@@ -237,6 +238,9 @@ table#myTable tbody tr:last-child td {
 table tfoot th {
   border: none;
   padding: 10px 18px 2em 18px;
+}
+table.tablesorter.myTable.dataTable.no-footer.fixedHeader-floating {
+  box-shadow: none;
 }
 
 @media only screen and (max-width: 660px) {


### PR DESCRIPTION
This pull request fixes `rv-html-report` command directory creation bug [happened here in travis-ci](https://travis-ci.com/yiyi-rv/dhcpcd/jobs/142444075#L771).  
I think this issue is probably caused by race condition, so now we create directory in a safer way according to [this stackoverflow answer](https://stackoverflow.com/questions/273192/how-can-i-safely-create-a-nested-directory-in-python#answer-273227).  
This pull request also fixes a minor css error.
