### PR TITLE
Carlton's atomic_thread_fence() fix.

### DIFF
--- a/llvm/ngrt/fence.h
+++ b/llvm/ngrt/fence.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 Runtime Verification, Inc.  All rights reserved. */
+/* Copyright (c) 2018 Runtime Verification, Inc.  All rights reserved. */
 
 #ifndef _RVP_FENCE_H_
 #define _RVP_FENCE_H_


### PR DESCRIPTION
Ensure that we can link programs for which clang generates an LLVM thread-fence instruction.