### PR TITLE
Fix the `tags` target by taking away the `.include <mkc.init.mk>` at the

### DIFF
--- a/llvm/ngrt/Makefile
+++ b/llvm/ngrt/Makefile
@@ -12,8 +12,6 @@
 TARGET_CC?=clang
 CC?=$(TARGET_CC)
 
-.include <mkc.init.mk>
-
 .include "../../cross-libdir.mk"
 
 LIB?=rvprt


### PR DESCRIPTION
top of the Makefile: it caused our custom `mk.conf` to be evaluated before
important variables like `SRCS` were set.  TBD: fix other Makefiles?

I hope this doesn't break something else.  I guess that the automated tests will tell us.