### PR TITLE
Add a new option flag, `-b`, that makes `rvpdump` print the bytes

### DIFF
--- a/llvm/librvread/reader.h
+++ b/llvm/librvread/reader.h
@@ -16,6 +16,7 @@ typedef enum _rvp_output_type {
 typedef struct _rvp_output_params {
 	rvp_output_type_t	op_type;
 	bool			op_emit_generation;
+	bool			op_emit_bytes;
 	size_t			op_nrecords;
 } rvp_output_params_t;
 
@@ -93,10 +94,12 @@ struct _rvp_pstate {
 	uint32_t		ps_idepth;
 	int			ps_zeromasknum;
 	bool			ps_emit_generation;
+	bool			ps_emit_bytes;
 };
 
 void rvp_trace_dump(const rvp_output_params_t *, int);
-void rvp_trace_dump_with_emitters(bool, size_t, const rvp_emitters_t *, int);
+void rvp_trace_dump_with_emitters(bool, bool, size_t, const rvp_emitters_t *,
+    int);
 
 __END_EXTERN_C
 

--- a/llvm/rvpdump/main.c
+++ b/llvm/rvpdump/main.c
@@ -18,7 +18,7 @@ static void __dead
 usage(const char *progname)
 {
 	fprintf(stderr,
-	    "usage: %s [-g] "
+	    "usage: %s [-b] [-g] "
 	    "[-t <binary|plain|symbol-friendly>] [-n #traces]\n"
 	    "[<trace file>]\n", progname);
 	exit(EXIT_FAILURE);
@@ -33,12 +33,13 @@ main(int argc, char **argv)
 	rvp_output_params_t op = {
 	  .op_type = RVP_OUTPUT_PLAIN_TEXT
 	, .op_emit_generation = false
+	, .op_emit_bytes = false
 	, .op_nrecords = SIZE_MAX
 	};
 	intmax_t tmpn;
 	char *end;
 
-	while ((ch = getopt(argc, argv, "gn:t:")) != -1) {
+	while ((ch = getopt(argc, argv, "bgn:t:")) != -1) {
 		switch (ch) {
 		case 'n':
 			errno = 0;
@@ -58,6 +59,9 @@ main(int argc, char **argv)
 			if (tmpn < 0 || SIZE_MAX < tmpn)
 				errx(EXIT_FAILURE, "-n %jd: out range", tmpn);
 			op.op_nrecords = tmpn;
+			break;
+		case 'b':
+			op.op_emit_bytes = true;
 			break;
 		case 'g':
 			op.op_emit_generation = true;

--- a/llvm/rvpdump/rvpdump.1
+++ b/llvm/rvpdump/rvpdump.1
@@ -1,4 +1,4 @@
-.Dd March 8, 2018
+.Dd November 16, 2018
 .Dt RVPDUMP 1
 .Os Linux
 .Sh NAME
@@ -8,6 +8,7 @@
 trace file in human-readable form.
 .Sh SYNOPSIS
 .Nm 
+.Op Fl b
 .Op Fl g
 .Op Fl n Ar number
 .Op Fl t Ar binary
@@ -33,6 +34,8 @@ data & instruction addresses.
 Command-line options modify the behavior of
 .Nm :
 .Bl -tag -width "... symbol-friendly"
+.It Fl b
+Print every event with the bytes comprising it in hexadecimal.
 .It Fl g
 Print every event with a generation number.
 .It Fl n Ar number


### PR DESCRIPTION
comprising each event in hexadecimal.