### PR TITLE
Omit mentions of rvpx(1), removed in 8c74da6fd67816893d4f5c923a63db0e1952a284

### DIFF
--- a/scripts/rvpa.1
+++ b/scripts/rvpa.1
@@ -1,4 +1,4 @@
-.Dd July 19, 2018
+.Dd November 27, 2018
 .Dt RVPA 1
 .Os Linux
 .Sh NAME
@@ -334,8 +334,7 @@ returns 3 if it finds
 .Tn Java ,
 but the version is not late enough.
 .Sh SEE ALSO
-.Xr rvpc 1 ,
-.Xr rvpx 1
+.Xr rvpc 1
 .Sh HISTORY
 .Tn RV-Predict/C
 1.9 was released in February 2018.

--- a/scripts/rvpc.1
+++ b/scripts/rvpc.1
@@ -4,7 +4,7 @@
 .\"
 .\" The uncommented requests are required for all man pages.
 .\" The commented requests should be uncommented and used where appropriate.
-.Dd April 23, 2018
+.Dd November 27, 2018
 .Dt rvpc 1
 .Os Linux
 .Sh NAME
@@ -458,8 +458,7 @@ Several example programs are in
 .\" Cross-references should be ordered by section (low to high), then in
 .\"     alphabetical order.
 .Xr clang 1 ,
-.Xr rvpa 1 ,
-.Xr rvpx 1
+.Xr rvpa 1
 .Sh STANDARDS
 .Nm
 respects the definition of data races between threads given in the

--- a/scripts/rvpsymbolize.1
+++ b/scripts/rvpsymbolize.1
@@ -1,4 +1,4 @@
-.Dd March 9, 2018
+.Dd November 27, 2018
 .Dt RVPSYMBOLIZE 1
 .Os Linux
 .Sh NAME
@@ -31,11 +31,9 @@ as a source for the DWARF debugging information that it uses to symbolize
 addresses.
 .Pp
 .Xr rvpa 1
-and
-.Xr rvpx 1
-use
+uses
 .Nm
-to symbolize their data-race reports.
+to symbolize its data-race reports.
 .Nm
 can be used in conjunction with
 .Xr rvpdump 1
@@ -78,8 +76,7 @@ cannot parse its arguments, it returns 1.
 Otherwise, it returns 0.
 .Sh SEE ALSO
 .Xr rvpa 1 ,
-.Xr rvpc 1 ,
-.Xr rvpx 1
+.Xr rvpc 1
 .Sh HISTORY
 .Tn RV-Predict/C
 1.9 was released in February 2018.


### PR DESCRIPTION
closes #978.