### PR TITLE
[Close it if you want] Add clang-format support to format C/C++/Java code.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+AlwaysBreakTemplateDeclarations: true
+AllowShortFunctionsOnASingleLine: Inline
+BreakAfterJavaFieldAnnotations: true
+BreakBeforeBraces: Linux
+SpaceAfterCStyleCast: true
+IndentCaseLabels: true
+AccessModifierOffset: -4
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterNamespace: false
+    AfterClass: false
+    AfterFunction: false
+
+BreakConstructorInitializersBeforeComma: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BinPackParameters: false
+ReflowComments: false
+---
+Language: Cpp
+ColumnLimit: 100
+---
+Language: Java
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: None
+BreakBeforeBinaryOperators: NonAssignment

--- a/formatCode.py
+++ b/formatCode.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import os.path
+path = os.getcwd()
+
+for root, dirs, files in os.walk(path):
+  ## Skip directories
+  # if root.endswith("/aes") or root.endswith("/openssl") or (root.find("/build/generated/") != -1):
+  #   continue
+  for name in files:
+    if (name.endswith(".h") or name.endswith(".c") or name.endswith(".hpp") or name.endswith(".cpp") or name.endswith(".java")):
+      localpath = root + '/' + name
+      print localpath
+      os.system("clang-format -i %s -style=File" %(localpath))


### PR DESCRIPTION
This pull request supports you to use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to format C/C++/Java code in RV-Predict repository.

You may want to have `clang-format` installed: `sudo apt install clang-format`. 

* `.clang-format`
Defines the [style options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) we used to format code.

* `formatCode.py`
The scripts that calls `clang-format` to format code.
You might want to modify it to skip the directories or files that you don't want to format.

So you run `./formatCode.py` to format code in repository.

(I didn't run it and commit the formatted code because I don't know which directories or files to skip).

Feel free to close this PR.
Thanks!